### PR TITLE
Añade preguntas oficiales UAH C1 por origen

### DIFF
--- a/public/api/db-uah-tec-aux-archivos-bibliotecas-2025.json
+++ b/public/api/db-uah-tec-aux-archivos-bibliotecas-2025.json
@@ -5840,6 +5840,6485 @@
         "path": "data/uah-bibliotecas-2025/tema_22_derechos_autor_lpi_creative_commons_uah.md",
         "highlightText": "Propiedad intelectual y Creative Commons"
       }
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q001-483029eff7ff",
+      "topicId": "uah-bib-t01-contenido",
+      "question": "¿Qué afirmación es correcta respecto al artículo 27 de la Constitución Española?",
+      "options": [
+        "La enseñanza superior es obligatoria y gratuita",
+        "Se reconoce a las personas físicas y jurídicas la libertad de creación de centros docentes, dentro del respeto a los principios constitucionales",
+        "No se reconoce la autonomía de las Universidades",
+        "Solo los españoles tienen derecho a la educación"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 1. Respuesta validada por la plantilla oficial: Se reconoce a las personas físicas y jurídicas la libertad de creación de centros docentes, dentro del respeto a los principios constitucionales. Clasificada como Tema 1 (Constitución Española) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q001",
+        "path": "data/general/01_constitucion_espanola_1978.md",
+        "highlightText": "Se reconoce a las personas físicas y jurídicas la libertad de creación de centros docentes, dentro del respeto a los principios constitucionales"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-001",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q003-2b0ea0d655ac",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "Según el artículo 9 del Real Decreto Legislativo 5/2015, de 30 de octubre, por el que se aprueba el texto Refundido del Estatuto Básico del Empleado Público, ¿A quién corresponde el ejercicio de las funciones que impliquen la participación directa o indirecta en el ejercicio de las potestades públicas o en la salvaguardia de los intereses generales del Estado y de las Administraciones Públicas?",
+      "options": [
+        "A los funcionarios de carrera",
+        "Al personal directivo",
+        "A los funcionarios de carrera y al personal laboral fijo",
+        "A los funcionarios públicos"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 3. Respuesta validada por la plantilla oficial: A los funcionarios públicos. Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q003",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "A los funcionarios públicos"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-002",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q004-be8e7c9c9070",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "Según el artículo 15 del Real Decreto Legislativo 5/2015, de 30 de octubre, por el que se aprueba el texto refundido de la Ley del Estatuto Básico del Empleado Público, ¿cuál de las siguientes respuestas es un derecho individual ejercido colectivamente?",
+      "options": [
+        "La libre asociación profesional",
+        "Las vacaciones, descansos, permisos y licencias",
+        "El ejercicio de la huelga, con la garantía del mantenimiento de los servicios esenciales de la comunidad",
+        "La inamovilidad en la condición de funcionario de carrera"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 4. Respuesta validada por la plantilla oficial: El ejercicio de la huelga, con la garantía del mantenimiento de los servicios esenciales de la comunidad. Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q004",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "El ejercicio de la huelga, con la garantía del mantenimiento de los servicios esenciales de la comunidad"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-002",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q009-6a27351b5a8a",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "La Ley Organica 3/2018, de 5 de diciembre, de protección de datos personales y garantía de los derechos digitales, tiene por objeto:",
+      "options": [
+        "Garantizar los derechos digitales de la ciudadanía conforme al mandato establecido en el artículo 18.1 de la Constitución",
+        "Garantizar los derechos digitales de la ciudadanía conforme al mandato establecido en el artículo 18.2 de la Constitución",
+        "Garantizar los derechos digitales de la ciudadanía conforme al mandato establecido en el artículo 18.3 de la Constitución",
+        "Garantizar los derechos digitales de la ciudadanía conforme al mandato establecido en el artículo 18.4 de la Constitución"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 9. Respuesta validada por la plantilla oficial: Garantizar los derechos digitales de la ciudadanía conforme al mandato establecido en el artículo 18.4 de la Constitución. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q009",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Garantizar los derechos digitales de la ciudadanía conforme al mandato establecido en el artículo 18.4 de la Constitución"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q011-87c8598b103b",
+      "topicId": "uah-bib-t06-contenido",
+      "question": "¿Qué tipo de acciones permite la Ley Orgánica 3/2007, de 22 de marzo, para la Igualdad efectiva de mujeres y hombres, para corregir situaciones de desigualdad de hecho entre mujeres y hombres?",
+      "options": [
+        "Acciones represivas",
+        "Acciones judiciales exclusivamente",
+        "Acciones positivas",
+        "Acciones sancionadoras"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 11. Respuesta validada por la plantilla oficial: Acciones positivas. Clasificada como Tema 6 (Igualdad) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q011",
+        "path": "data/general/06_Ley_Organica_3_2007_de_22_de_marzo_para_la_igualdad_efectiva_de_mujeres_y_hombres.md",
+        "highlightText": "Acciones positivas"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-006",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q012-2c3c1ac6e8d2",
+      "topicId": "uah-bib-t06-contenido",
+      "question": "En virtud del artículo 12.3 de la Ley Orgánica 3/2007 para la igualdad efectiva de mujeres y hombres, ¿quién está legitimado en los litigios sobre acoso sexual y acoso por razón de sexo?",
+      "options": [
+        "La persona acosada",
+        "El empleador o la empresa implicada",
+        "Cualquier testigo directo del acoso",
+        "Solo el Ministerio fiscal cuando se trate de personas menores de edad y emancipados"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 12. Respuesta validada por la plantilla oficial: La persona acosada. Clasificada como Tema 6 (Igualdad) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q012",
+        "path": "data/general/06_Ley_Organica_3_2007_de_22_de_marzo_para_la_igualdad_efectiva_de_mujeres_y_hombres.md",
+        "highlightText": "La persona acosada"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-006",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q015-4bd72209b212",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 2 de la Ley Orgánica 2/2023, de 22 de marzo del Sistema Universitario (LOSU), son funciones del sistema universitario:",
+      "options": [
+        "La generación, desarrollo, difusión, transferencia e intercambio del conocimiento",
+        "El fomento y la gestión de programas de movilidad propios o promovidos por las Administraciones Públicas:",
+        "El establecimiento de sus relaciones de puestos de trabajo o plantillas, y su eventual modificación",
+        "La propuesta y determinación de la estructura y organización de la oferta de enseñanzas universitarias oficiales, así como de enseñanzas propias universitarias, incluida la formación a lo largo de la vida"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 15. Respuesta validada por la plantilla oficial: La generación, desarrollo, difusión, transferencia e intercambio del conocimiento. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q015",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "La generación, desarrollo, difusión, transferencia e intercambio del conocimiento"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q016-475487c1acca",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Qué derecho se reconoce en la Ley Orgánica 2/2023, de 22 de marzo del Sistema Universitario (LOSU), al personal técnico, de gestión y de administración y servicios en relación con su carrera profesional?",
+      "options": [
+        "Solo pueden promocionar cambiando de puesto de trabajo",
+        "Pueden desarrollar su carrera profesional sin cambiar de puesto, mediante progresión en grado, categoría o nivel",
+        "Solo pueden ascender mediante oposición externa",
+        "No tienen derecho a progresión profesional"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 16. Respuesta validada por la plantilla oficial: Pueden desarrollar su carrera profesional sin cambiar de puesto, mediante progresión en grado, categoría o nivel. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q016",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Pueden desarrollar su carrera profesional sin cambiar de puesto, mediante progresión en grado, categoría o nivel"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q018-c1fc6ae4321e",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según los Estatutos de la UPM se convocará sesión extraordinaria del Claustro Universitario o se incluirán puntos en el orden del día de una sesión ordinaria a propuesta motivada de:",
+      "options": [
+        "La Comisión de Gobierno",
+        "Al menos la tercera parte de los componentes del claustro.",
+        "La mesa del claustro",
+        "El Rector"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 18. Respuesta validada por la plantilla oficial: La mesa del claustro. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q018",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "La mesa del claustro"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q019-6ea8b7540171",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "¿Qué protege la Ley de Propiedad Intelectual?",
+      "options": [
+        "Marcas comerciales",
+        "Derechos de los autores sobre sus obras",
+        "Patentes",
+        "Derechos de los editores"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 19. Respuesta validada por la plantilla oficial: Derechos de los autores sobre sus obras. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q019",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Derechos de los autores sobre sus obras"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q021-3027f62dc7ca",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Qué es el identificador ROR?",
+      "options": [
+        "Elidentificador ROR (Research Output Rate) tiene forma de URL, y es un enlace que lleva a la ficha con los índices de citas de un investigador",
+        "El identificador ROR (Resource Outdated Result) tiene forma de URL, y esun enlace que lleva a la ficha con los recursos no activos de una biblioteca",
+        "El identificador ROR (Research Organization Registry) tiene forma de URL, y es un enlace que lleva a la ficha de registro de la institución",
+        "El identificador ROR (Restricted Outsider Resources) tiene forma de URL, y es Ñ un enlace que lleva a la ficha de recursos restringidos a los usuarios de una institución"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 21. Respuesta validada por la plantilla oficial: El identificador ROR (Research Organization Registry) tiene forma de URL, y es un enlace que lleva a la ficha de registro de la institución. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q021",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "El identificador ROR (Research Organization Registry) tiene forma de URL, y es un enlace que lleva a la ficha de registro de la institución"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q022-8e8be77d8260",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Qué modelo de publicación en acceso abierto no cobra ni a los autores ni a los lectores?",
+      "options": [
+        "Acceso abierto dorado",
+        "Acceso abierto verde",
+        "Acceso abierto diamante",
+        "Acceso abierto híbrido"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 22. Respuesta validada por la plantilla oficial: Acceso abierto diamante. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q022",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Acceso abierto diamante"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q025-5bf7b95b1abe",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "En el ámbito de la comunicación científica, son identificadores únicos persistentes de un investigador:",
+      "options": [
+        "ORCID y PURL",
+        "CVN y ORCID",
+        "ORCID y ResearcherID",
+        "DOI y ORCID"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 25. Respuesta validada por la plantilla oficial: ORCID y ResearcherID. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q025",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "ORCID y ResearcherID"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q026-efdb03dd836d",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Qué SIGB ha elegido la Library of Congress en 2023?",
+      "options": [
+        "Absys",
+        "Koha-Kobli",
+        "Symphony",
+        "Folio '"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 26. Respuesta validada por la plantilla oficial: Folio '. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q026",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Folio '"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q027-abe9e1f182e2",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "La Declaración de San Francisco (DORA) de 2012 trata sobre:",
+      "options": [
+        "Acceso abierto",
+        "Catalogación",
+        "Evaluación científica",
+        "Revistas depredadoras"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 27. Respuesta validada por la plantilla oficial: Evaluación científica. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q027",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "Evaluación científica"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q028-69b7ae5dacb1",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "¿Qué siglas identifican el Marco europeo de competencias digitales?",
+      "options": [
+        "Plan",
+        "SERVQUAL",
+        "LibQUAL",
+        "DigComp"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 28. Respuesta validada por la plantilla oficial: DigComp. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q028",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "DigComp"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q029-c4e188582988",
+      "topicId": "uah-bib-t08-contenido",
+      "question": "¿Qué organización internacional promueve la integridad y transparencia en la investigación científica?",
+      "options": [
+        "COPE",
+        "OpenDoar",
+        "OCLC",
+        "IFLA"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 29. Respuesta validada por la plantilla oficial: COPE. Clasificada como Tema 8 (Código ético) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q029",
+        "path": "data/general/08_codigo-etico-general-UAH.md",
+        "highlightText": "COPE"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-008",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q030-8058fb5024a0",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cómo se denomina la iniciativa que requiere que todas las publicaciones científicas que resulten de investigaciones financiadas con subvenciones públicas deben publicarse en revistas o plataformas de acceso abierto?",
+      "options": [
+        "EOSC",
+        "OpenAIRE",
+        "APCs",
+        "Plan"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 30. Respuesta validada por la plantilla oficial: Plan. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q030",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Plan"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q032-1af9520c4028",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Qué identificador se usa comúnmente en publicaciones científicas para enlaces permanentes?",
+      "options": [
+        "ISBN",
+        "ISSN",
+        "DOI",
+        "ISNI"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 32. Respuesta validada por la plantilla oficial: DOI. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q032",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "DOI"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q033-79aade4987b0",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "¿Qué son los metadatos en el contexto bibliotecario?",
+      "options": [
+        "Términos equivalentes que se usan para facilitar la recuperación de la información",
+        "Palabras clave asignadas a cada recurso en los catálogos bibliográficos",
+        "Datos estructurados que describen recursos.",
+        "Etiquetas físicas utilizadas para el control de préstamos"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 33. Respuesta validada por la plantilla oficial: Datos estructurados que describen recursos.. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q033",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Datos estructurados que describen recursos."
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q035-6676005096fb",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "¿Cuál es el primer paso en la gestión de la colección bibliográfica?",
+      "options": [
+        "Selección de materiales",
+        "Expurgo",
+        "Encuadernación",
+        "Préstamo"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 35. Respuesta validada por la plantilla oficial: Selección de materiales. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q035",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "Selección de materiales"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-012",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q036-3de62aa14e8c",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "Zotero permite:",
+      "options": [
+        "Escanear libros",
+        "Comprar artículos",
+        "Gestionar referencias y generar citas",
+        "Traducir referencias"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 36. Respuesta validada por la plantilla oficial: Gestionar referencias y generar citas. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q036",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Gestionar referencias y generar citas"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q037-6cb5e13aba97",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "En el sistema MARC 21, los campos para el ISBN y el ISSN son respectivamente:",
+      "options": [
+        "020 y030",
+        "020 y 022",
+        "022 y 021",
+        "024 y 028"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 37. Respuesta validada por la plantilla oficial: 020 y 022. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q037",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "020 y 022"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q039-9661fecaf80a",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "En el contexto de los metadatos, el término \"interoperabilidad\" se refiere a:",
+      "options": [
+        "La capacidad de traducir metadatos",
+        "La compatibilidad entre distintos sistemas y esquemas de metadatos",
+        "El uso de un solo estándar global",
+        "La conversión automática a MARC"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 39. Respuesta validada por la plantilla oficial: La compatibilidad entre distintos sistemas y esquemas de metadatos. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q039",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "La compatibilidad entre distintos sistemas y esquemas de metadatos"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q040-d7e49271bbe1",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "¿Qué rol cumple RDF en el ecosistema semántico de las bibliotecas digitales?",
+      "options": [
+        "Codifica imágenes",
+        "Encripta catálogos,",
+        "Estructura los datos para su interpretación por máquinas",
+        "Sustituye a los metadatos MARC"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 40. Respuesta validada por la plantilla oficial: Estructura los datos para su interpretación por máquinas. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q040",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Estructura los datos para su interpretación por máquinas"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q042-aa3a258fca65",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "¿Qué protocolo utiliza el Archivo Digital UPM para que sean recolectados sus metadatos?",
+      "options": [
+        "HTTP Secure (HTTPS)",
+        "Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH)",
+        "File Transfer Protocol (FTP)",
+        "Simple Object Access Protocol (SOAP)"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 42. Respuesta validada por la plantilla oficial: Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH). Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q042",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH)"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q044-83e29df2a819",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál es el agregador nacional de repositorios institucionales de acceso abierto?",
+      "options": [
+        "FECYT",
+        "ANECA",
+        "RECOLECTA",
+        "CNEAI"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 44. Respuesta validada por la plantilla oficial: RECOLECTA. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q044",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "RECOLECTA"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q047-ccb65da430dd",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Qué es la alfabetización informacional?",
+      "options": [
+        "Enseñanza de técnicas de lectura comprensiva aplicadas a textos académicos",
+        "Formación en aspectos legales relacionados con el uso de fuentes de información, como el copyright",
+        "Desarrollo de habilidades para localizar, evaluar y usar información de forma eficaz",
+        "Diseño de actividades para fomentar el hábito lector entre públicos específicos, como adolescentes"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 47. Respuesta validada por la plantilla oficial: Desarrollo de habilidades para localizar, evaluar y usar información de forma eficaz. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q047",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Desarrollo de habilidades para localizar, evaluar y usar información de forma eficaz"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q048-6ff8a4359e78",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Qué competencia forma parte de la alfabetización informacional?",
+      "options": [
+        "Seleccionar y aplicar herramientas tecnológicas para facilitar el acceso estructurado a recursos digitales en entornos virtuales",
+        "Capacidad para discriminar la fiabilidad de las fuentes de información y aplicar normas de citación adecuadas",
+        "Elaborar soportes de comunicación y materiales informativos dirigidos a la difusión de contenidos especializados",
+        "Aplicar protocolos operativos para la administración de equipamiento documental en espacios de consulta y préstamo"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 48. Respuesta validada por la plantilla oficial: Capacidad para discriminar la fiabilidad de las fuentes de información y aplicar normas de citación adecuadas. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q048",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Capacidad para discriminar la fiabilidad de las fuentes de información y aplicar normas de citación adecuadas"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q050-6c1e2852c41e",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál de las siguientes vías de publicación en acceso abierto consiste en el autoarchivo en un repositorio?",
+      "options": [
+        "Vía dorada",
+        "Vía híbrida",
+        "Vía verde",
+        "Vía editorial"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 50. Respuesta validada por la plantilla oficial: Vía verde. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q050",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Vía verde"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q052-284723a76939",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Cuál es el objetivo principal de un identificador persistente como el Handle o el DO! en los repositorios?",
+      "options": [
+        "Proteger derechos de autor.",
+        "Garantizar un enlace permanente al recurso digital",
+        "Determinar la editorial",
+        "Sustituir al ISBN."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 52. Respuesta validada por la plantilla oficial: Garantizar un enlace permanente al recurso digital. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q052",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "Garantizar un enlace permanente al recurso digital"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q053-e9c859926602",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Qué papel cumple el autoarchivo en el modelo de acceso abierto verde?",
+      "options": [
+        "Remite al editor directamente",
+        "Publica solo tesis",
+        "Permite al autor depositar su obra en un repositorio institucional",
+        "Bloquea el acceso durante un embargo"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 53. Respuesta validada por la plantilla oficial: Permite al autor depositar su obra en un repositorio institucional. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q053",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Permite al autor depositar su obra en un repositorio institucional"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q055-4021200d76c9",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Qué organismo español impulsa políticas de ciencia abierta y repositorios?",
+      "options": [
+        "ANECA",
+        "CNEAI",
+        "FECYT",
+        "UNED"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 55. Respuesta validada por la plantilla oficial: FECYT. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q055",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "FECYT"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q057-d2a7ecdec16b",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Qué principio define el marco ACRL para la alfabetización informacional en la educación superior?",
+      "options": [
+        "Consulta masiva",
+        "La información como construcción social y contextual",
+        "Publicación editorial",
+        "Control exclusivo de la fuente"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 57. Respuesta validada por la plantilla oficial: La información como construcción social y contextual. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q057",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "La información como construcción social y contextual"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q058-215ccd6b0448",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "¿Qué papel desempeña la biblioteca universitaria en Moodle?",
+      "options": [
+        "Proporciona únicamente enlaces externos sin participación activa en la plataforma",
+        "Solo se utiliza como repositorio de documentos PDF sin intervención formativa",
+        "Integración de recursos, guías temáticas y apoyo en competencias informacionales",
+        "Solo ofrece acceso al catálogo de la biblioteca, sin conexión con los cursos"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 58. Respuesta validada por la plantilla oficial: Integración de recursos, guías temáticas y apoyo en competencias informacionales. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q058",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "Integración de recursos, guías temáticas y apoyo en competencias informacionales"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-010",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q060-c3e57bddc0e9",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "¿Qué es un sexenio en el contexto universitario español?",
+      "options": [
+        "Una beca de investigación",
+        "Un cargo académico",
+        "Un periodo de seis años de evaluación de actividad investigadora",
+        "Una ayuda para el estudio"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 60. Respuesta validada por la plantilla oficial: Un periodo de seis años de evaluación de actividad investigadora. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q060",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "Un periodo de seis años de evaluación de actividad investigadora"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q063-c3085094ad92",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "Open Researcher 8. Contributor ID es una organización internacional sin ánimo de lucro que proporciona:",
+      "options": [
+        "Una web social interdisciplinar de apoyo a los investigadores y centrada en sus necesidades",
+        "Un espacio abierto para que los investigadores puedan compartir sus conocimientos",
+        "Un identificador único y persistente para autores del ámbito científico y académico que permite eliminar la ambigúedad entre su investigación y la de otro investigador",
+        "Una url única compuesta de 12 dígitos, por ejemplo http://orcid.org/0001.0002.0003, que identifica a un autor de forma unívoca"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 63. Respuesta validada por la plantilla oficial: Un identificador único y persistente para autores del ámbito científico y académico que permite eliminar la ambigúedad entre su investigación y la de otro investigador. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q063",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "Un identificador único y persistente para autores del ámbito científico y académico que permite eliminar la ambigúedad entre su investigación y la de otro investigador"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q066-4c7609c6852c",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál de las siguientes herramientas bibliométricas es de acceso abierto?",
+      "options": [
+        "Web of Science",
+        "Dimensions",
+        "JCR",
+        "InCites"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 66. Respuesta validada por la plantilla oficial: Dimensions. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q066",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Dimensions"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q071-46812b373b71",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Qué son las publicaciones híbridas?",
+      "options": [
+        "Revistas solo en papel",
+        "Revistas que ofrecen acceso abierto y también bajo suscripción",
+        "Libros en otro idioma",
+        "Documentos sin derechos"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 71. Respuesta validada por la plantilla oficial: Revistas que ofrecen acceso abierto y también bajo suscripción. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q071",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Revistas que ofrecen acceso abierto y también bajo suscripción"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q073-e377c3c555a3",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "¿Qué característica tienen los libros electrónicos académicos en consorcios bibliotecarios?",
+      "options": [
+        "Acceso local",
+        "Acceso multiusuario, licencias compartidas y modelos por suscripción o compra perpetua",
+        "Solo disponibles en inglés",
+        "Descarga limitada"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 73. Respuesta validada por la plantilla oficial: Acceso multiusuario, licencias compartidas y modelos por suscripción o compra perpetua. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q073",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "Acceso multiusuario, licencias compartidas y modelos por suscripción o compra perpetua"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q075-4df76385a17a",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "La biblioteca universitaria se define, en términos generales, como:",
+      "options": [
+        "Un archivo histórico de documentos oficiales",
+        "Un servicio académico que gestiona recursos de información para apoyar la docencia, el estudio y la investigación",
+        "Una empresa privada de préstamo comercial",
+        "Un museo dedicado a libros antiguos"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 75. Respuesta validada por la plantilla oficial: Un servicio académico que gestiona recursos de información para apoyar la docencia, el estudio y la investigación. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q075",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "Un servicio académico que gestiona recursos de información para apoyar la docencia, el estudio y la investigación"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-010",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q076-ecee466c755d",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "Horizonte Europa (2021-2027) es un programa que incide en las bibliotecas ya que:",
+      "options": [
+        "Promueve la ciencia abierta y el acceso abierto a los resultados de investigación",
+        "Financia la construcción de edificios bibliotecarios",
+        "Obliga a destruir tesis anteriores a 2000",
+        "Restringe el uso de repositorios institucionales"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 76. Respuesta validada por la plantilla oficial: Promueve la ciencia abierta y el acceso abierto a los resultados de investigación. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q076",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Promueve la ciencia abierta y el acceso abierto a los resultados de investigación"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q077-a1e1c37ba601",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "La cooperación bibliotecaria permite principalmente:",
+      "options": [
+        "Competir por suscriptores de revistas",
+        "Compartir recursos y optimizar gastos mediante acuerdos y consorcios",
+        "Sustituir los catálogos locales por comerciales",
+        "Reducir el número de bibliotecarios"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 77. Respuesta validada por la plantilla oficial: Compartir recursos y optimizar gastos mediante acuerdos y consorcios. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q077",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "Compartir recursos y optimizar gastos mediante acuerdos y consorcios"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q078-48c441e60174",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "El catálogo colectivo REBIUN facilita:",
+      "options": [
+        "Exclusivamente la compraventa de libros usados",
+        "La localización de fondos de todas las bibliotecas miembros",
+        "La suscripción a bases de datos comerciales.",
+        "Certificados de asistencia a cursos"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 78. Respuesta validada por la plantilla oficial: La localización de fondos de todas las bibliotecas miembros. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q078",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "La localización de fondos de todas las bibliotecas miembros"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q079-d201b153d502",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según la normativa UPM, el órgano colegiado que aprueba la política bibliotecaria es:",
+      "options": [
+        "El Consejo Social",
+        "El Claustro de Profesores",
+        "El Consejo de Gobierno:",
+        "El Consejo de Estudiantes"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 79. Respuesta validada por la plantilla oficial: El Consejo de Gobierno:. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q079",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "El Consejo de Gobierno:"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q080-958843797cb0",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "El préstamo de portátiles al alumnado es un servicio clasificado como:",
+      "options": [
+        "Referencia virtual",
+        "Intercambio científico",
+        "Adquisición bibliográfica",
+        "Apoyo al aprendizaje y a la docencia"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 80. Respuesta validada por la plantilla oficial: Apoyo al aprendizaje y a la docencia. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q080",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Apoyo al aprendizaje y a la docencia"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q081-9c30faff0755",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "El reglamento de la Biblioteca UPM establece que el carné de biblioteca es:",
+      "options": [
+        "Reemplazable por el DNI sin identificación electrónica",
+        "Obligatorio solo para profesorado",
+        "Personal e intransferible para cualquier usuario autorizado",
+        "Válido solo durante dos semanas"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 81. Respuesta validada por la plantilla oficial: Personal e intransferible para cualquier usuario autorizado. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q081",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "Personal e intransferible para cualquier usuario autorizado"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-010",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q082-c90834b0d88d",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "Para publicar un artículo en acceso abierto, la Biblioteca UPM ofrece:",
+      "options": [
+        "Asesoramiento sobre licencias Creative Commons y financiación de APC en revistas seleccionadas",
+        "Eliminación de los derechos de autor",
+        "Solo copias impresas gratuitas",
+        "Prohibición de depositar en repositorios"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 82. Respuesta validada por la plantilla oficial: Asesoramiento sobre licencias Creative Commons y financiación de APC en revistas seleccionadas. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q082",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Asesoramiento sobre licencias Creative Commons y financiación de APC en revistas seleccionadas"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q083-28e903db0fd7",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "El servicio de préstamo interbibliotecario de la Biblioteca UPM tiene como objetivo:",
+      "options": [
+        "Obtener documentos que no están disponibles en sus fondos propios",
+        "Prestar equipamiento informático a otros campus",
+        "Vender duplicados de la colección",
+        "Organizar exposiciones temporales"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 83. Respuesta validada por la plantilla oficial: Obtener documentos que no están disponibles en sus fondos propios. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q083",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Obtener documentos que no están disponibles en sus fondos propios"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q085-841847e8fe07",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "El objetivo principal de la preservación documental es:",
+      "options": [
+        "Aumentar el número de préstamos",
+        "Garantizar el acceso y la legibilidad a largo plazo de los documentos",
+        "Reducir el tamaño de la colección",
+        "Eliminar duplicados físicos:"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 85. Respuesta validada por la plantilla oficial: Garantizar el acceso y la legibilidad a largo plazo de los documentos. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q085",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Garantizar el acceso y la legibilidad a largo plazo de los documentos"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q087-a787f8eb5eb7",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "El modelo OAIS (ISO 14721) es una referencia internacional para:",
+      "options": [
+        "Diseño de edificios bibliotecarios",
+        "Medición de impacto bibliométrico",
+        "Sistemas de preservación digital a largo plazo",
+        "Catalogación de libros impresos"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 87. Respuesta validada por la plantilla oficial: Sistemas de preservación digital a largo plazo. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q087",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Sistemas de preservación digital a largo plazo"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q088-688144f942ed",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "Entre los formatos recomendados para la preservación digital de imágenes se incluye:",
+      "options": [
+        "TIFF sin compresión o con compresión sin pérdida",
+        "JPEG con alta compresión",
+        "GIF animado",
+        "BMP sin comprimir"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 88. Respuesta validada por la plantilla oficial: TIFF sin compresión o con compresión sin pérdida. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q088",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "TIFF sin compresión o con compresión sin pérdida"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-012",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q089-e86ebce8e4f8",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "PREMIS es un estándar que describe:",
+      "options": [
+        "Metadatos de preservación de objetos digitales",
+        "Requisitos de accesibilidad web",
+        "Códigos de catalogación musical",
+        "Directrices de redes sociales"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 89. Respuesta validada por la plantilla oficial: Metadatos de preservación de objetos digitales. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q089",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Metadatos de preservación de objetos digitales"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q091-6547e64937fc",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "La evaluación de servicios bibliotecarios basada en la opinión de usuarios se realiza habitualmente con la encuesta internacional:",
+      "options": [
+        "LibQUAL+",
+        "EFQM Express",
+        "SERVQUAL",
+        "Eurostat"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 91. Respuesta validada por la plantilla oficial: LibQUAL+. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q091",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "LibQUAL+"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q094-4c50ef0c6f62",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "Linked Open Data (LOD) se apoya técnicamente en el estándar:",
+      "options": [
+        "RDF (Resource Description Framework)",
+        "SQL",
+        "ASCII",
+        "XSLT"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 94. Respuesta validada por la plantilla oficial: RDF (Resource Description Framework). Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q094",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "RDF (Resource Description Framework)"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q095-6affeabf8f20",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "Un ejemplo de aplicación de LOD en bibliotecas universitarias es:",
+      "options": [
+        "Resolver préstamos en papel",
+        "Publicar datos de autores y materias del catálogo para reutilización externa",
+        "Codificar registros MARC en PDF",
+        "Cerrar el catálogo al público"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 95. Respuesta validada por la plantilla oficial: Publicar datos de autores y materias del catálogo para reutilización externa. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q095",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "Publicar datos de autores y materias del catálogo para reutilización externa"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-upm-c1-2025-1-q096-4e42162aef09",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "Para licenciar datos bibliográficos abiertos se recomienda habitualmente:",
+      "options": [
+        "Licencia CC0 o Creative Commons Atribución",
+        "NDA (acuerdo de confidencialidad)",
+        "Copyright completo sin excepciones",
+        "Patente industrial"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad Politécnica de Madrid 2025 - Técnico Auxiliar de Biblioteca C1 - Primer ejercicio, pregunta 96. Respuesta validada por la plantilla oficial: Licencia CC0 o Creative Commons Atribución. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "upm-c1-2025-1#q096",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Licencia CC0 o Creative Commons Atribución"
+      },
+      "tags": [
+        "examen-oficial",
+        "upm-c1-2025-1",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q004-6fb5be83468d",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 25 del Decreto 101/2004 del 13 de mayo, por el que 30 aprueban los Estatutos de la UDC, NO es una función del Claustro:",
+      "options": [
+        "Elaborar la reforma de los Estatutos de la Universidad",
+        "Aprobar la planificación estratégica y las líneas generales de la programación plurianual y presupuestaria",
+        "Elegir, por mayoría simple, al defensor universitario, aprobar su reglamento y conocer la memoria anual sobre su actividad",
+        "Convocar, con carácter extraordinario, elecciones al rector por iniciativa de un tercio de sus miembros y con la aprobación de dos tercios"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 4. Respuesta validada por la plantilla oficial: Convocar, con carácter extraordinario, elecciones al rector por iniciativa de un tercio de sus miembros y con la aprobación de dos tercios. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q004",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Convocar, con carácter extraordinario, elecciones al rector por iniciativa de un tercio de sus miembros y con la aprobación de dos tercios"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q009-c51f3ada7ec9",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "El artículo 12 de la Ley Orgánica 2/2023, de 22 de marzo, del Sistema Universitario establece que el personal docente e investigador deberá depositar una copia de la versión final aceptada para publicación y los datos asociados a la misma en repositorios institucionales o temáticos de acceso abierto...",
+      "options": [
+        "con carácter previo a la fecha de publicación — *",
+        "con carácter posterior a la fecha de publicación",
+        "de forma simultánea a la fecha de publicación",
+        "indistintamente de la fecha de publicación"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 9. Respuesta validada por la plantilla oficial: de forma simultánea a la fecha de publicación. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q009",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "de forma simultánea a la fecha de publicación"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q036-855549cf75b3",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "Si se busca por materias las bases de datos de ciencias sociales en la página web de la BUDC, NO está?",
+      "options": [
+        "Derecho",
+        "Historia",
+        "Moda",
+        "Educación"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 36. Respuesta validada por la plantilla oficial: Historia. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q036",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "Historia"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q038-2a8e805f4a27",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Qué servicios ofrece la BUDC?",
+      "options": [
+        "Apoyo ala investigación, apoyo al aprendizaje, adquisiciones, formación de usuarios, información, préstamo y préstamo interbibliotecario",
+        "Apoyo a la investigación, apoyo al aprendizaje, apoyo a la docencia, adquisiciones, formación de usuarios, información, préstamo, préstamo interbibliotecario y donación de publicaciones",
+        "Apoyo ala investigación, apoyo al aprendizaje, adquisiciones, formación de usuarios, información, colección electrónica, préstamo interbibliotecario y donación de publicaciones",
+        "Apoyo ala investigación, apoyo al aprendizaje, adquisiciones, formación de usuarios, información, préstamo, préstamo interbibliotecario y donación de publicaciones"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 38. Respuesta validada por la plantilla oficial: Apoyo ala investigación, apoyo al aprendizaje, adquisiciones, formación de usuarios, información, préstamo, préstamo interbibliotecario y donación de publicaciones. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q038",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Apoyo ala investigación, apoyo al aprendizaje, adquisiciones, formación de usuarios, información, préstamo, préstamo interbibliotecario y donación de publicaciones"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q041-6ae6074feb4d",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "¿Cuál de estas licencias Creative Commons permite usar la obra libremente para cualquier fin sin necesidad de solicitar permiso al autor de tal obra?",
+      "options": [
+        "CC BY-NC-ND",
+        "CC BY-NC-SA",
+        "CC BY-ND",
+        "CC0"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 41. Respuesta validada por la plantilla oficial: CC0. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q041",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "CC0"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q042-c50179bc05c1",
+      "topicId": "uah-bib-t11-contenido",
+      "question": "Según las \"Normas y directrices para bibliotecas universitarias y científicas\" de REBIUN (2* ed, aum., 1999), las condiciones ambientales en los depósitos de bibliotecas estarán permanentemente controladas mediante:",
+      "options": [
+        "Termómetros y controladores de humedad",
+        "Dispositivos de control ambiental",
+        "Medidores de humedad relativa y temperatura ambiental",
+        "Termohigrógrafos y psicrómetros"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 42. Respuesta validada por la plantilla oficial: Termohigrógrafos y psicrómetros. Clasificada como Tema 11 (Organización espacial y equipamiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q042",
+        "path": "data/uah-bibliotecas-2025/referencias/11_organizacion_espacial_equipamiento_buah.md",
+        "highlightText": "Termohigrógrafos y psicrómetros"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-011",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q045-03bd8232dec2",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "Según el punto 5 de la Normativa xeral relativa 4 protección de datos persoais na UDC, el encargado de evaluar las solicitudes presentadas sobre el ejercicio de los derechos reconocidos en la LOPD y en el RGPD será:",
+      "options": [
+        "El Delegado de Protección de Datos",
+        "La Secretaria Xeral",
+        "La Asesoría Xuridica",
+        "La Xerencia"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 45. Respuesta validada por la plantilla oficial: El Delegado de Protección de Datos. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q045",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "El Delegado de Protección de Datos"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q048-a420389c823d",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "¿Qué criterio NO se considera válido en el expurgo de la colección?",
+      "options": [
+        "Elespacio disponible",
+        "La obsolescencia:",
+        "Laredundancia",
+        "El origen de los fondos"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 48. Respuesta validada por la plantilla oficial: El origen de los fondos. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q048",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "El origen de los fondos"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-012",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q049-60766903c5ee",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "Señale la respuesta que contiene consorcios de bibliotecas universitarias españolas",
+      "options": [
+        "BUVAL, BUGALICIA, MADROÑO",
+        "BUCLE, UNIRIS, CSUC",
+        "CSIC, CISUG, BUVAL",
+        "CBUA, G9, CSUC"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 49. Respuesta validada por la plantilla oficial: BUVAL, BUGALICIA, MADROÑO. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q049",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "BUVAL, BUGALICIA, MADROÑO"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q051-6ebb5ff4bac2",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "¿Por qué medio puede tramitarse la solicitud de documentos objeto de donación de la BUDC?",
+      "options": [
+        "Por teléfono",
+        "Personalmente",
+        "— Mediante una solicitud en línea en la página web de la BUDC",
+        "Todas son correctas"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 51. Respuesta validada por la plantilla oficial: Personalmente. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q051",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "Personalmente"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-012",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q052-a2ac96b64c08",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "Señale cuál de las siguientes afirmaciones es FALSA. Entre las ventajas de usar licenzas Creative Commons está que:",
+      "options": [
+        "Son revocables",
+        "Enel ambito de la enseñanza, ofrecen multitud de contenidos libres para ser usados y compartidos",
+        "Permiten la divulgación de la obra sin perjuicio de que el autor o autora reserven algunos derechos",
+        "Aumentan la visibilidad de las autoras o autores en internet"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 52. Respuesta validada por la plantilla oficial: Son revocables. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q052",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Son revocables"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q056-fad6ab6896a9",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "Cual de los siguientes NO es un criterio RECOLECTA para la evaluación de repositorios institucionales de investigación citados en la \"Guía para la evaluación de Repositorios Institucionales de Investigación\" de Rebiun",
+      "options": [
+        "Accesibilidad.",
+        "Visibilidad",
+        "Políticas",
+        "Logs e estadísticas"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 56. Respuesta validada por la plantilla oficial: Accesibilidad.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q056",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Accesibilidad."
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q059-39332ec55273",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "Señala en que tipo de depósito es requisito que el/la autor/a del taba, conceda al Repositorio una licencia de distribución no exclusiva por la a autoriza al RUC a archivar, difundir en abierto y preservar dicho trabajo",
+      "options": [
+        "— En el depósito mediante archivo delegado y depósito por archivo directo se la BUDC",
+        "Tanto en depósito en autoarchivo como en archivo delegado",
+        "Enel depósito de archivo directo de la biblioteca",
+        "En cualquer tipo de depósito"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 59. Respuesta validada por la plantilla oficial: Tanto en depósito en autoarchivo como en archivo delegado. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q059",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Tanto en depósito en autoarchivo como en archivo delegado"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q060-ef6dccdc04ec",
+      "topicId": "uah-bib-t11-contenido",
+      "question": "¿Cuál de estos sistemas NO se usaría para la clasificación y ordenación topográfica de una biblioteca con libre acceso?",
+      "options": [
+        "Clasificación Decimal Universal (CDU)",
+        "Clasificación Decimal de Dewey (DDC)",
+        "Clasificación de la Library of Congress (LC)",
+        "Numerus currens"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 60. Respuesta validada por la plantilla oficial: Numerus currens. Clasificada como Tema 11 (Organización espacial y equipamiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q060",
+        "path": "data/uah-bibliotecas-2025/referencias/11_organizacion_espacial_equipamiento_buah.md",
+        "highlightText": "Numerus currens"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-011",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q066-bb8b4f090076",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "El marco normativo de política de seguridad de información y protección de datos personales de la UDC tiene los siguientes niveles:",
+      "options": [
+        "Dos: Política y normas generales",
+        "Tres: Política, normas generales y reglamentos específicos",
+        "Cuatro: Política, normas generales, procedimientos y recomendaciones",
+        "Cinco: Política, normas generales, reglamentos, procedimientos y recomendaciones '"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 66. Respuesta validada por la plantilla oficial: Cuatro: Política, normas generales, procedimientos y recomendaciones. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q066",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Cuatro: Política, normas generales, procedimientos y recomendaciones"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q067-70a4934055e8",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Señala cual de las siguientes afirmaciones es correcta según el documento Condicións de préstamo, operativas desde el 19.12.2022:",
+      "options": [
+        "Desde el momento de la devolución, el usuario será sancionado sin poder llevar libros tantos días hábiles como documentos con préstamo vencido tenga y días de retraso acumule, hasta un máximo de 40 días.",
+        "Los usuarios del grupo 6 no tienen acceso al préstamo de portátiles y accesorios",
+        "El profesorado visitante puede llevar 35 documentos en préstamo y la duración del préstamo es por curso académico",
+        "El préstamo BIC solo admite dos renovaciones"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 67. Respuesta validada por la plantilla oficial: Desde el momento de la devolución, el usuario será sancionado sin poder llevar libros tantos días hábiles como documentos con préstamo vencido tenga y días de retraso acumule, hasta un máximo de 40 días.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q067",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Desde el momento de la devolución, el usuario será sancionado sin poder llevar libros tantos días hábiles como documentos con préstamo vencido tenga y días de retraso acumule, hasta un máximo de 40 días."
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q072-6c9e53dd6d7d",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "nla pantalla de resultados de Crunia, entre los filtros de búsqueda NO está:",
+      "options": [
+        "Ladisponibilidad",
+        "El tipo de préstamo",
+        "El tipo de recurso",
+        "La autoria"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 72. Respuesta validada por la plantilla oficial: El tipo de préstamo. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q072",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "El tipo de préstamo"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q079-50f7ae47262d",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "La búsqueda avanzada en Crunia NO permite escoger el campo:",
+      "options": [
+        "Docente de la materia",
+        "ISBN",
+        "Código de la materia",
+        "Director de trabajo de grado/máster"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 79. Respuesta validada por la plantilla oficial: Director de trabajo de grado/máster. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q079",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Director de trabajo de grado/máster"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q081-228f7cf0a794",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "En el Plan estratégico de Rebiun vigente, el impacto de la inteligencia artificial en las bibliotecas universitarias:",
+      "options": [
+        "Esel ambito 3 de la línea estratégica 2",
+        "Eselámbito 1 de la línea estratégica 2",
+        "Esel ámbito 2 de la línea estratégica 3",
+        "—Eselámbito 4 de la línea estratégica 4"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 81. Respuesta validada por la plantilla oficial: —Eselámbito 4 de la línea estratégica 4. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q081",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "—Eselámbito 4 de la línea estratégica 4"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q082-13be0894e5b0",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "¿Qué se consideran datos personales según la Resolución reitoral del 22 de julio por la que se aprueba la política de seguridad de la información y protección de datos personales en la UDC?:",
+      "options": [
+        "Información creada, recibida o utilizada en las actividades de la UDC",
+        "Toda la información sobre una persona física identificada o identificable",
+        "— DNIENIE, n° de pasaporte, dirección postal o electrónica, imagen, voz, n° de la seguridad social o mutualidad, teléfono, fax, marcas físicas, nombre y dos apellidos, firma, firma electrónica, tarjeta sanitaria",
+        "Datos que tienen un contenido semántico (es decir, significado) en un contexto determinado"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 82. Respuesta validada por la plantilla oficial: Toda la información sobre una persona física identificada o identificable. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q082",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Toda la información sobre una persona física identificada o identificable"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q089-5536b1df9ff4",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "Promover la formación del personal en IA mediante la realización de jornadas sobre IA online para el personal técnico es...",
+      "options": [
+        "un objetivo de BNELab para avanzar en el análisis y posibilidades de aplicación de IA en la generación de nuevo conocimiento",
+        "un objetivo del área 4 de los objetivos del Observatorio de Inteligencia Artificial de Rebiun",
+        "unobjetivo de la BUDC para adecuar la biblioteca a los nuevos tiempos",
+        "un objetivo clave de la \"Declaración de la IFLA sobre Bibliotecas e Inteligencia Artificial\""
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 89. Respuesta validada por la plantilla oficial: un objetivo del área 4 de los objetivos del Observatorio de Inteligencia Artificial de Rebiun. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q089",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "un objetivo del área 4 de los objetivos del Observatorio de Inteligencia Artificial de Rebiun"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-udc-c1-2025-2-q101-d015c53778ff",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "Indica cual es la sentencia correcta respecto a Rebiun:",
+      "options": [
+        "Actualmente es una red asociada a la Sectorial CRUE I+D+i",
+        "Está formada por bibliotecas de universidades públicas y el CSIC",
+        "Tiene un repositorio institucional llamado RUC",
+        "Actualmente es una Comisión Sectorial de CRUE"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidade da Coruña 2025 - Auxiliar Técnico de Biblioteca - Segundo ejercicio, pregunta 101. Respuesta validada por la plantilla oficial: Actualmente es una red asociada a la Sectorial CRUE I+D+i. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "udc-c1-2025-2#q101",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "Actualmente es una red asociada a la Sectorial CRUE I+D+i"
+      },
+      "tags": [
+        "examen-oficial",
+        "udc-c1-2025-2",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q001-73ff887fd020",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "El Servei de Biblioteques i Documentació de la Universitat de Valencia pertenece a un grupo de compra para la adquisición conjunta de fondos bibliográficos que se denomina:",
+      "options": [
+        "UPNA",
+        "UNIR -",
+        "UNIRIS",
+        "UAX"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 1. Respuesta validada por la plantilla oficial: UNIRIS. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q001",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "UNIRIS"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-012",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q002-d1c225117a21",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "En el artículo 2 de la Ley orgánica 2/2023, del sistema universitario se señala literalmente que el sistema universitario presta y garantiza el. servicio público de la educación superior universitaria mediante:",
+      "options": [
+        "la generación de conocimiento, su transmisión y crítica.",
+        "la docencia, la investigación y la transferencia del conocimiento.",
+        "el estudio, la formación, la investigación y la cultura.",
+        "el acceso a la cultura y al estudio a toda la sociedad valenciana."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 2. Respuesta validada por la plantilla oficial: la docencia, la investigación y la transferencia del conocimiento.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q002",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "la docencia, la investigación y la transferencia del conocimiento."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q003-693eb747aa55",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Cómo se denomina el asistente de ALMA que proporciona recomendaciones para mejorar sus flujos de trabajo y optimizar mejor su uso?",
+      "options": [
+        "DORA",
+        "DARA",
+        "SARA",
+        "MARA '"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 3. Respuesta validada por la plantilla oficial: DARA. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q003",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "DARA"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q004-49e2bb53b107",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "Según el artículo 26 de la Ley orgánica 3/2018, de 5 de diciembre, de protección de datos personales y garantía de los derechos digitales:",
+      "options": [
+        "Será lícito el tratamiento por las administraciones públicas de datos con fines de archivo en interés público.",
+        "El tratamiento de datos relativos a infracciones y sanciones administrativas por parte de las bibliotecas, incluido el mantenimiento de registros relacionados con las mismas, deberá siempre contar con el consentimiento del interesado.",
+        "En ningún caso las administraciones públicas podrán tratar los datos personales.",
+        "El consentimiento del afectado bastará para levantar la prohibición del tratamiento de datos cuya finalidad principal sea identificar su ideología, afiliación sindical, religión, orientación sexual, creencias u origen racial o étnico."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 4. Respuesta validada por la plantilla oficial: Será lícito el tratamiento por las administraciones públicas de datos con fines de archivo en interés público.. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q004",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Será lícito el tratamiento por las administraciones públicas de datos con fines de archivo en interés público."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q005-883c906c7c7b",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Qué subcomunidades encontramos en la comunidad Investigación del repositorio institucional de la Universitat de Valencia RODERIC?",
+      "options": [
+        "Preprints, datos de investigación y capítulos de libro",
+        "E-prints, revistas y datos de investigación",
+        "Datos de investigación, tesis y eprints",
+        "Revistas, datos de investigación y postprints"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 5. Respuesta validada por la plantilla oficial: E-prints, revistas y datos de investigación. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q005",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "E-prints, revistas y datos de investigación"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q006-77d3ad263d3b",
+      "topicId": "uah-bib-t06-contenido",
+      "question": "La Ley orgánica 3/2007, de 22 de marzo para la igualdad efectiva de mujeres y hombres, señala en su artículo 51 que las administraciones públicas, en el ámbito de sus respectivas competencias y en aplicación del principio de igualdad entre mujeres y hombres, deberán fomentar la formación en igualdad:",
+      "options": [
+        "Principalmente como parte de planes internos de formación continua.",
+        "En elacceso al empleo público.",
+        "En función de las necesidades detectadas en cada organismo.",
+        "De manera progresiva y según la disponibilidad de recursos."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 6. Respuesta validada por la plantilla oficial: En elacceso al empleo público.. Clasificada como Tema 6 (Igualdad) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q006",
+        "path": "data/general/06_Ley_Organica_3_2007_de_22_de_marzo_para_la_igualdad_efectiva_de_mujeres_y_hombres.md",
+        "highlightText": "En elacceso al empleo público."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-006",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q008-f57ea4a0b6d4",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "Según la Recomendación de la UNESCO sobre ciencia abierta (2021), ¿cuál de los siguientes elementos NO forma parte de los principios o prácticas promovidos por esta recomendación?",
+      "options": [
+        "Open peer review.",
+        "OER",
+        "Citizen science",
+        "S20"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 8. Respuesta validada por la plantilla oficial: S20. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q008",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "S20"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q009-ffef963dc59f",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "El nombre de la licencia Creative Commons correspondiente con las siguientes siglas CC BY NC es:",
+      "options": [
+        "Reconocimiento — No comercial 4",
+        "Reconocimiento — No derivadas",
+        "Reconocimiento — No comercial — No derivadas",
+        "Reconocimiento — Compartir igual"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 9. Respuesta validada por la plantilla oficial: Reconocimiento — No comercial 4. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q009",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Reconocimiento — No comercial 4"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q013-19c55a3d1dd2",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "Aunque algunos de los siguientes repositorios permiten el depósito de diferentes tipos de materiales, ¿cuál de ellos está especializado en el depósito de datos de investigación?",
+      "options": [
+        "CORA.RDR",
+        "RODERIC",
+        "RUA",
+        "idUS Pagina 3 fp a —"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 13. Respuesta validada por la plantilla oficial: CORA.RDR. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q013",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "CORA.RDR"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q016-a93afa7f5f7d",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "La Lista de encabezamientos de materia en catalán (LEMAC) es un lenguaje controlado empleado para la catalogación temática o indexación de los documentos. Contiene los registros de autoridad de materia adaptados de:",
+      "options": [
+        "BNE",
+        "SUDOC",
+        "CCBIP",
+        "LCSH"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 16. Respuesta validada por la plantilla oficial: LCSH. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q016",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "LCSH"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q017-2fb2a7fdec44",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "La Ley orgánica 2/2023, del sistema universitario, señala en el artículo 32, que la concesión de las becas y ayudas al estudio responderá prioritaria y fundamentalmente a criterios socioeconómicos, sin perjuicio de los criterios académicos y de otros criterios que puedan, en su caso, establecer las bases reguladoras, atendiendo a:",
+      "options": [
+        "La discapacidad y sus necesidades de apoyo.",
+        "La preferencia de estudios en universidades privadas.",
+        "El orden de inscripción en la solicitud.",
+        "Ninguna de las respuestas anteriores es correcta."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 17. Respuesta validada por la plantilla oficial: La discapacidad y sus necesidades de apoyo.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q017",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "La discapacidad y sus necesidades de apoyo."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q020-5e7b2efa27fd",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 44 del Reglamento de régimen interno del Servei de Biblioteques i Documentació su reforma es aprobada por:",
+      "options": [
+        "El Consejo de Gobierno",
+        "El Consejo de Dirección",
+        "El Claustro de la Universitat de Valencia",
+        "La Comisión del Servei de Biblioteques i Documentació"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 20. Respuesta validada por la plantilla oficial: El Consejo de Gobierno. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q020",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "El Consejo de Gobierno"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q022-d22ac60f5a28",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "El Servei de Biblioteques i Documentació tiene entre sus fondos la primera edición de la obra La ciudad y la vida de Carmen Alborch. ¿En qué etiqueta del formato MARC 21 conciso para registros bibliográficos colocaremos la información sobre la primera edición?",
+      "options": [
+        "222",
+        "250",
+        "245",
+        "658"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 22. Respuesta validada por la plantilla oficial: 250. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q022",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "250"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q023-aedec6c050ba",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "Según el organigrama del Servei de Biblioteques i Documentació, NO es una sección central:",
+      "options": [
+        "Calidad en la Gestión Bibliotecaria",
+        "Comunicación y Formación",
+        "Apoyo a la Investigación",
+        "Gestión de Recursos de Información"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 23. Respuesta validada por la plantilla oficial: Calidad en la Gestión Bibliotecaria. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q023",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "Calidad en la Gestión Bibliotecaria"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q024-a7596883ebf8",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "En la herramienta de descubrimiento Trobes existe una opción para realizar búsquedas por índices. ¿Cuáles son todos los índices disponibles por los que se puede realizar esta búsqueda?",
+      "options": [
+        "Autoría, signatura, materia y título",
+        "Autoría, editor, materia y título",
+        "Autoría, editor y título",
+        "Autoría, materia y título"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 24. Respuesta validada por la plantilla oficial: Autoría, signatura, materia y título. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q024",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Autoría, signatura, materia y título"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q025-f268090dff2e",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "Según el artículo 12 de la Ley del Estatuto básico del empleado público, los órganos de gobierno que pueden disponer de personal eventual se determinan mediante:",
+      "options": [
+        "Real decreto del Gobierno de la nación.",
+        "El propio Estatuto básico del empleado público.",
+        "Las leyes de la función pública que se dicten en desarrollo del Estatuto básico del empleado público.",
+        "El gobierno de la comunidad autónoma correspondiente."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 25. Respuesta validada por la plantilla oficial: Las leyes de la función pública que se dicten en desarrollo del Estatuto básico del empleado público.. Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q025",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "Las leyes de la función pública que se dicten en desarrollo del Estatuto básico del empleado público."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-002",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q026-03bef34343e3",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál es el nombre actual del buscador de políticas de acceso abierto de la organización JISC?",
+      "options": [
+        "Open Policy Finder",
+        "Global Open Policy Director",
+        "Sherpa Romeo 2.0",
+        "JISC Policy Toolkit"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 26. Respuesta validada por la plantilla oficial: Open Policy Finder. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q026",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Open Policy Finder"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q028-8dea6f4fc827",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "Según las RDA y el formato MARC 21, ¿cuál es la forma correcta de representar la función del autor en un campo 100 de una autoridad personal?",
+      "options": [
+        "100 1% $$a Soriano, Ramón, $$e autor",
+        "100 1# $$a Soriano, Ramón, $$a autor",
+        "100 1% $$a Soriano, Ramón, $$d autor",
+        "100 1% $$a Soriano, Ramón, $$y autor"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 28. Respuesta validada por la plantilla oficial: 100 1% $$a Soriano, Ramón, $$e autor. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q028",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "100 1% $$a Soriano, Ramón, $$e autor"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q034-653f36512131",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "De las siguientes afirmaciones sobre el IDR de Dialnet, señala la respuesta INCORRECTA:",
+      "options": [
+        "El IDR es un instrumento que nos permite saber cuál es el impacto científico de una revista, su evolución y su posición respecto al resto de las revistas de la especialidad.",
+        "Por cada ámbito temático, este indicador se basa en el análisis del número de citas que han recibido los artículos publicados en los cinco años anteriores relativo al número de publicaciones.",
+        "Por cada ámbito temático, este indicador se basa en el análisis del número de citas que han recibido las revistas en los cinco años anteriores relativo al número de artículos.",
+        "El índice IDR fue publicado por primera vez bajo el paraguas de Dialnet _ - Métricas en noviembre de 2018."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 34. Respuesta validada por la plantilla oficial: Por cada ámbito temático, este indicador se basa en el análisis del número de citas que han recibido las revistas en los cinco años anteriores relativo al número de artículos.. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q034",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Por cada ámbito temático, este indicador se basa en el análisis del número de citas que han recibido las revistas en los cinco años anteriores relativo al número de artículos."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q035-c73654b25dfd",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "Según consta en la página web del Servei de Biblioteques i Documentació, ¿qué órgano participa en la autoevaluación del servicio, se encarga de la supervisión de las mejoras y define e implementa los canales de comunicación para detectar las necesidades y expectativas de los diferentes grupos de interés?",
+      "options": [
+        "La Comisión del Servei de Biblioteques i Documentació",
+        "La Junta Técnica",
+        "El Comité de Calidad 3 ñ",
+        "La Unitat de Qualitat de la Universitat de Valencia"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 35. Respuesta validada por la plantilla oficial: El Comité de Calidad 3 ñ. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q035",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "El Comité de Calidad 3 ñ"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q036-ab911ba6c02a",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Cuáles de los siguientes documentos NO son objeto de préstamo en las bibliotecas de la Universitat de Valéncia?",
+      "options": [
+        "Manuscritos e impresos de especial valor patrimonial",
+        "Libros con ilustraciones en color",
+        "Manuales de uso frecuente",
+        "Obras anteriores a 1960"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 36. Respuesta validada por la plantilla oficial: Manuscritos e impresos de especial valor patrimonial. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q036",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Manuscritos e impresos de especial valor patrimonial"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q039-150b981a3280",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "¿Cómo se entiende y qué función tiene un trial en el proceso de adquisición de recursos en una biblioteca?",
+      "options": [
+        "Son recursos de información que las diferentes empresas del sector bibliotecario ofrecen a sus clientes para que los testeen, con la obligación de adquirirlos o suscribirlos.*",
+        "Programas de difícil instalación. Xx 7",
+        "Recursos de información que las diferentes empresas del sector bibliotecario ofrecen a sus clientes para que los testeen antes de adquirirlos o suscribirlos.",
+        "Recursos de información adquiridos desde hace tiempo y que siempre dan un servicio adecuado. x"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 39. Respuesta validada por la plantilla oficial: Recursos de información que las diferentes empresas del sector bibliotecario ofrecen a sus clientes para que los testeen antes de adquirirlos o suscribirlos.. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q039",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "Recursos de información que las diferentes empresas del sector bibliotecario ofrecen a sus clientes para que los testeen antes de adquirirlos o suscribirlos."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-012",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q042-66a1b77fd051",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "En la CDU (Clasificación Decimal Universal), ¿qué significado tiene el auxiliar con el signo igual entre paréntesis (=...)?",
+      "options": [
+        "Auxiliar de idioma",
+        "Auxiliar de lugar",
+        "Auxiliar de grupos étnicos",
+        "Auxiliar de forma"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 42. Respuesta validada por la plantilla oficial: Auxiliar de grupos étnicos. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q042",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "Auxiliar de grupos étnicos"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q043-951fa1af2d05",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "La Universitat de Valéncia participa en el proyecto Dialnet realizando el vaciado de revistas y la indización de capítulos de obras colectivas y congresos editados por la Universidad. ¿Cuál de las siguientes afirmaciones NO es correcta?",
+      "options": [
+        "La Universitat de Valéncia participa en el proyecto Dialnet desde 2005.",
+        "El objetivo es dar visibilidad a la producción de la Universitat de Valencia, priorizando las publicaciones editadas por la Universitat y la calidad de la información de los autores de la Universitat.",
+        "Las propuestas para el vaciado de nuevas revistas vienen exclusivamente del propio Dialnet.",
+        "En 2013, se propone ampliar los criterios incluyendo también las obras en colaboración, en las que participe un profesor de la Universitat de Valencia, aunque no esté editado o coeditado por la Universitat."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 43. Respuesta validada por la plantilla oficial: Las propuestas para el vaciado de nuevas revistas vienen exclusivamente del propio Dialnet.. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q043",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "Las propuestas para el vaciado de nuevas revistas vienen exclusivamente del propio Dialnet."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q046-c8362016eb8c",
+      "topicId": "uah-bib-t05-contenido",
+      "question": "Según la 4? Carta de Servicios del Servei de Biblioteques i Documentació de la Universitat de Valéncia, ¿cómo se mide el compromiso 10 \"Mantener actualizada la información relativa a las personas con discapacidad en la sección de accesibilidad en la web del Servei de Biblioteques i documentació\"?",
+      "options": [
+        "Con el indicador 14: grado de cumplimiento de la revisión trimestral en la sección de Accesibilidad en la web del Servei de Biblioteques i Documentació.",
+        "Con el indicador 15: grado de satisfacción de los estudiantes con la información que se proporciona en la sección de Accesibilidad en la web del SBD.",
+        "Con el indicador 10: índice de satisfacción de los estudiantes sobre los servicios que se relacionan en la web.",
+        "Con el indicador 10: índice de satisfacción del PDI sobre los servicios que se relacionan en la web. i"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 46. Respuesta validada por la plantilla oficial: Con el indicador 14: grado de cumplimiento de la revisión trimestral en la sección de Accesibilidad en la web del Servei de Biblioteques i Documentació.. Clasificada como Tema 5 (Discapacidad) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q046",
+        "path": "data/uah-bibliotecas-2025/tema_05_discapacidad_educacion_trabajo_uah.md",
+        "highlightText": "Con el indicador 14: grado de cumplimiento de la revisión trimestral en la sección de Accesibilidad en la web del Servei de Biblioteques i Documentació."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-005",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q047-383143f6f718",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "¿Cuál de las siguientes opciones corresponde a una linea estratégica del V Plan Estratégico de REBIUN?",
+      "options": [
+        "La biblioteca como agente estratégico para el impulso de la economía universal.",
+        "La biblioteca como agente estratégico de un planeta más habitable.",
+        "La biblioteca como agente estratégico y motor de cambio.",
+        "La biblioteca como agente estratégico para el impulso de la ciencia abierta."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 47. Respuesta validada por la plantilla oficial: La biblioteca como agente estratégico para el impulso de la ciencia abierta.. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q047",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "La biblioteca como agente estratégico para el impulso de la ciencia abierta."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q048-0520c280b2d1",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "Según las Normas y directrices para bibliotecas universitarias y científicas de REBIUN, la colección básica de una biblioteca universitaria ha de disponer de:",
+      "options": [
+        "5.000 volúmenes",
+        "10.000 volúmenes",
+        "50.000 volúmenes",
+        "30.000 volúmenes"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 48. Respuesta validada por la plantilla oficial: 50.000 volúmenes. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q048",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "50.000 volúmenes"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-010",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q049-f4e006df21e5",
+      "topicId": "uah-bib-t07-contenido",
+      "question": "Según el artículo 35 de la Ley 31/1995, de 8 de noviembre, de prevención de riesgos laborales, los delegados de prevención serán designados:",
+      "options": [
+        "Por el empresario",
+        "Por y entre los representantes del personal",
+        "Por el personal de la empresa",
+        "Por el Comité de Seguridad y Salud *"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 49. Respuesta validada por la plantilla oficial: Por y entre los representantes del personal. Clasificada como Tema 7 (Prevención de riesgos laborales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q049",
+        "path": "data/general/07_Plan-de-Prevencion_UAH.md",
+        "highlightText": "Por y entre los representantes del personal"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-007",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q051-fb4c002d907a",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "En el ámbito de la gestión bibliográfica, identifica cuál de las siguientes afirmaciones sobre herramientas para elaboración de citas es CORRECTA:.",
+      "options": [
+        "Mendeley permite no solo gestionar referencias bibliograficas, sino también colaborar en grupos y almacenar documentos en la nube.",
+        "Zotero carece de integración con procesadores de texto para insertar citas automáticamente.",
+        "EndNote es una herramienta gratuita que no requiere licencia para su uso avanzado.",
+        "RefWorks está diseñado exclusivamente para la gestión de citas en formato APA.."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 51. Respuesta validada por la plantilla oficial: Mendeley permite no solo gestionar referencias bibliograficas, sino también colaborar en grupos y almacenar documentos en la nube.. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q051",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Mendeley permite no solo gestionar referencias bibliograficas, sino también colaborar en grupos y almacenar documentos en la nube."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q052-1caba9dfd49a",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "¿Cómo se denomina el área 0 de las ISBD (descripción bibliográfica internacional normalizada) según su última actualización de 2021?",
+      "options": [
+        "Área de forma del contenido, proceso de producción y de tipo de medio",
+        "Área de forma de medio y tipo de contenido",
+        "Área de forma de medio",
+        "Área de tipo de contenido y de forma de medio ' Pagina 13"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 52. Respuesta validada por la plantilla oficial: Área de forma del contenido, proceso de producción y de tipo de medio. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q052",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Área de forma del contenido, proceso de producción y de tipo de medio"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q053-f43d08c91498",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "En la herramienta de descubrimiento Trobes, ¿puede un usuario externo acceder a 'Mi cuenta'?",
+      "options": [
+        "No puede acceder.",
+        "Solamente pueden acceder los usuarios de convenio.",
+        "Solamente pueden acceder los usuarios avalados.",
+        "Pueden acceder tanto los usuarios de convenios como los avalados."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 53. Respuesta validada por la plantilla oficial: Pueden acceder tanto los usuarios de convenios como los avalados.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q053",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Pueden acceder tanto los usuarios de convenios como los avalados."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q054-b05e6b8e1d2c",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "El 30 de julio de 2024 se lanzó el nuevo portal de revistas en acceso abierto de la Universitat de Valencia. ¿Qué nombre se ha escogido para designar a este portal?",
+      "options": [
+        "Arxiu Obert",
+        "Túria",
+        "Xúquer",
+        "SapiensUV"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 54. Respuesta validada por la plantilla oficial: Túria. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q054",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Túria"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q058-a13c40b44bc0",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "Según el proyecto DIGCOMP, la protección de datos es:",
+      "options": [
+        "Una competencia digital del área de Información y tratamiento de datos",
+        "Una competencia digital del área de Seguridad",
+        "Una competencia digital del área de Comunicación y colaboración",
+        "Una competencia digital del área de Resolución de problemas"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 58. Respuesta validada por la plantilla oficial: Una competencia digital del área de Seguridad. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q058",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Una competencia digital del área de Seguridad"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q059-9fd7027b4b0d",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Cuál es la estructura del código para publicaciones oficiales NIPO (número de identificación de las publicaciones oficiales)?",
+      "options": [
+        "Se compone de 9 números que se dividen en cuatro grupos separados por guiones.",
+        "Se compone de 9 números que se dividen en cuatro grupos separados por comas.",
+        "Se compone de 10 números que se dividen en cuatro grupos separados por guiones.",
+        "Se compone de 10 números que se dividen en cuatro grupos separados por comas. '"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 59. Respuesta validada por la plantilla oficial: Se compone de 9 números que se dividen en cuatro grupos separados por guiones.. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q059",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "Se compone de 9 números que se dividen en cuatro grupos separados por guiones."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q064-c432f6a8f42e",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "El plazo de préstamo de los ordenadores portátiles en las bibliotecas de la Universitat de Valéncia es:",
+      "options": [
+        "de 15 días y hasta 2 renovaciones",
+        "de 15 días y hasta 6 renovaciones",
+        "de 1 semana y hasta 6 renovaciones",
+        "de 1 mes y hasta 6 renovaciones"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 64. Respuesta validada por la plantilla oficial: de 15 días y hasta 6 renovaciones. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q064",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "de 15 días y hasta 6 renovaciones"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q065-69f7c5ef7436",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Cuál de las siguientes afirmaciones sobre la creación y gestión de perfiles de autor es CORRECTA?",
+      "options": [
+        "ResearcherID: el investigador no puede crear su perfil manualmente en WOS.",
+        "Scopus ID: se crea a partir de las referencias bibliográficas de esta base de datos de Elsevier cuando el autor tiene al menos cinco referencias indexadas.",
+        "ORCID: se crea rellenando el formulario y permite la importación de referencias bibliográficas desde múltiples plataformas.",
+        "Google Académico: este perfil se crea automáticamente a partir de las referencias bibliográficas indexadas en Google Scholar."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 65. Respuesta validada por la plantilla oficial: ORCID: se crea rellenando el formulario y permite la importación de referencias bibliográficas desde múltiples plataformas.. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q065",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "ORCID: se crea rellenando el formulario y permite la importación de referencias bibliográficas desde múltiples plataformas."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q069-95b3c65f267b",
+      "topicId": "uah-bib-t01-contenido",
+      "question": "La Constitución Española de 1978, en su artículo 76.1 en relación con las comisiones de investigación establece que:",
+      "options": [
+        "Se podrán nombrar exclusivamente por el. Senado.",
+        "El resultado de la investigación deberá comunicarse al presidente del Gobierno.",
+        "Sus conclusiones no serán vinculantes.",
+        "La a) y la b) son correctas."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 69. Respuesta validada por la plantilla oficial: Sus conclusiones no serán vinculantes.. Clasificada como Tema 1 (Constitución Española) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q069",
+        "path": "data/general/01_constitucion_espanola_1978.md",
+        "highlightText": "Sus conclusiones no serán vinculantes."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-001",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q070-e4ababf7e1b8",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Los documentos depositados en el repositorio institucional RODERIC se pueden localizar desde la herramienta de descubrimiento Trobes?",
+      "options": [
+        "Sí",
+        "Solamente si tienen licencia Creative Commons CC BY-NC 5.0",
+        "Solamente si tienen licencia Creative Commons CC BY-NC 4.0",
+        "No"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 70. Respuesta validada por la plantilla oficial: Sí. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q070",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Sí"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q071-fb2cb9a1a025",
+      "topicId": "uah-bib-t07-contenido",
+      "question": "¿Según el artículo 30 de la Ley 31/1995, de 8 de noviembre, de prevención y riesgos laborales, qué posibilidades tiene el empresario para cumplir con el deber de prevención de riesgos laborales?",
+      "options": [
+        "Deberá designar, en todo caso, uno o varios trabajadores para ocuparse de dicha actividad.",
+        "Necesariamente deberá concertar dicho servicio con una entidad especializada ajena a la empresa.",
+        "El empresario designará uno o varios trabajadores para ocuparse de dicha actividad, constituirá un servicio de prevención, o concertará dicho servicio con una entidad especializada ajena a la empresa.",
+        "El empresario deberá constituir un servicio de prevención o concertar dicho servicio con una entidad especializada ajena a la empresa."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 71. Respuesta validada por la plantilla oficial: El empresario designará uno o varios trabajadores para ocuparse de dicha actividad, constituirá un servicio de prevención, o concertará dicho servicio con una entidad especializada ajena a la empresa.. Clasificada como Tema 7 (Prevención de riesgos laborales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q071",
+        "path": "data/general/07_Plan-de-Prevencion_UAH.md",
+        "highlightText": "El empresario designará uno o varios trabajadores para ocuparse de dicha actividad, constituirá un servicio de prevención, o concertará dicho servicio con una entidad especializada ajena a la empresa."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-007",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q075-ac85d4bb4e6a",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "En relación con los procesos de autoevaluación realizados por el Servei de Biblioteques i Documentació de la Universitat de Valéncia, ¿cuál de las siguientes afirmaciones es correcta?",
+      "options": [
+        "El Servei de Biblioteques i Documentació ha realizado tres procesos de autoevaluación, siendo el último en 2024.",
+        "El Servei de Biblioteques i Documentació ha realizado dos procesos de autoevaluación, siendo el último en 2017.",
+        "El Servei de Biblioteques i Documentació ha realizado tres procesos de autoevaluación, siendo el último en 2023.",
+        "El Servei de Biblioteques i Documentació ha realizado dos procesos de autoevaluación, siendo el último en 2020."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 75. Respuesta validada por la plantilla oficial: El Servei de Biblioteques i Documentació ha realizado tres procesos de autoevaluación, siendo el último en 2023.. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q075",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "El Servei de Biblioteques i Documentació ha realizado tres procesos de autoevaluación, siendo el último en 2023."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q080-4ff72b777612",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "Según las Normas y directrices para bibliotecas universitarias y científicas de REBIUN, la colección de una biblioteca universitaria ha de tener un incremento anual de:",
+      "options": [
+        "5 volúmenes por PDI y 10 volúmenes por alumno",
+        "10 volúmenes por PDI y 1 volumen por alumno",
+        "2 volúmenes por alumno y 5 volúmenes por PDI",
+        "5 volúmenes por alumno y 10 volúmenes por PDI"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 80. Respuesta validada por la plantilla oficial: 10 volúmenes por PDI y 1 volumen por alumno. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q080",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "10 volúmenes por PDI y 1 volumen por alumno"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-010",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q082-68850ce85c5b",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Segun la normativa de préstamo interbibliotecario del Servei de Biblioteques i Documentació de la Universitat de Valéncia, en el caso de préstamo de originales, la devolución deberá realizarse en:",
+      "options": [
+        "la biblioteca del campus a la que está asignado el centro.",
+        "la sección de Préstamo Interbibliotecario (edificio de La Nau).",
+        "cualquier biblioteca de la Universitat de Valencia.",
+        "cualquier biblioteca del consorcio BUVAL."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 82. Respuesta validada por la plantilla oficial: la sección de Préstamo Interbibliotecario (edificio de La Nau).. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q082",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "la sección de Préstamo Interbibliotecario (edificio de La Nau)."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q083-4ebfcc1ba08d",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "Según la 4? Carta de Servicios del Servei de Biblioteques i Documentació de la Universitat de Valéncia, ¿en qué plazo se contestarán las quejas y sugerencias recibidas en la unidad?",
+      "options": [
+        "En un plazo máximo de quince días",
+        "En un plazo máximo de tres días",
+        "En un plazo máximo de cinco días",
+        "En un plazo máximo de un mes"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 83. Respuesta validada por la plantilla oficial: En un plazo máximo de un mes. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q083",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "En un plazo máximo de un mes"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q085-10cbdc426327",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Qué es el ISSN-L?",
+      "options": [
+        "Es un ISSN específico que se coloca en las revistas editadas en formato libro.",
+        "Es un ISSN específico que reúne los diferentes idiomas en los que se edita una misma publicación seriada..",
+        "Es un ISSN específico que reúne los diferentes títulos en los que se edita una misma publicación seriada.",
+        "Es un ISSN específico que reúne los diferentes soportes en los que se edita una misma publicación seriada."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 85. Respuesta validada por la plantilla oficial: Es un ISSN específico que reúne los diferentes soportes en los que se edita una misma publicación seriada.. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q085",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "Es un ISSN específico que reúne los diferentes soportes en los que se edita una misma publicación seriada."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q086-23ccc119e779",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "¿Cuál de las siguientes iniciativas y declaraciones NO está relacionada con la reforma de la evaluación de la investigación en el contexto actual?",
+      "options": [
+        "COARA",
+        "LEIDEN",
+        "ENCA",
+        "RERA"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 86. Respuesta validada por la plantilla oficial: RERA. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q086",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "RERA"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q088-54362a36918d",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "Según la Ley orgánica 3/2018, de 5 de diciembre, de protección de datos personales y garantía de los derechos digitales, ¿cuál de los siguientes NO es un derecho de los ciudadanos en relación con sus datos personales?",
+      "options": [
+        "Derecho de acceso",
+        "Derecho de rectificación",
+        "Derecho de oposición",
+        "Derecho de recopilación"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 88. Respuesta validada por la plantilla oficial: Derecho de recopilación. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q088",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Derecho de recopilación"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q089-0029ff877e6c",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "En la última resolución de la Comisión Nacional Evaluadora de la Actividad Investigadora (CNEAI) se mencionan varias métricas para demostrar el impacto de las aportaciones científicas. De las siguientes opciones, ¿cuáles corresponden a métricas relacionadas con citas normalizadas?",
+      "options": [
+        "Citescore, Scimago Journal Rank, IDR",
+        "Field-weighted Citation Impact (FWCI), Field Citation Ratio (FCR)",
+        "Dialnet Métricas, Dimensions, Google Académico",
+        "DOAB, DOAJ, Sello CEA-APQ"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 89. Respuesta validada por la plantilla oficial: Field-weighted Citation Impact (FWCI), Field Citation Ratio (FCR). Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q089",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Field-weighted Citation Impact (FWCI), Field Citation Ratio (FCR)"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q091-22284710b65d",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Cuál es la vigencia de la actual carta de servicios del Servei de Biblioteques i Documentació?",
+      "options": [
+        "Tres años a partir del día 01/01/2024",
+        "Cuatro años a partir del día 01/01/2024",
+        "Tres años a partir del día 01/01/2023",
+        "Cuatro años a partir del día 01/01/2023 |"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 91. Respuesta validada por la plantilla oficial: Cuatro años a partir del día 01/01/2024. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q091",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Cuatro años a partir del día 01/01/2024"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q092-a5820d07c728",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "Cuando se deposita un documento en el repositorio institucional RODERIC, ¿qué identificador persistente se genera?",
+      "options": [
+        "SICI",
+        "Handle",
+        "DOI",
+        "ORCID"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 92. Respuesta validada por la plantilla oficial: Handle. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q092",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "Handle"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q093-0771459a0aca",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "¿En qué etiqueta del formato MARC 21 conciso para registros bibliográficos colocaremos la información referente a la descripción física de una monografía?",
+      "options": [
+        "310",
+        "300 l",
+        "246",
+        "830"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 93. Respuesta validada por la plantilla oficial: 300 l. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q093",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "300 l"
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-013",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q094-43d7183dca8d",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Actualmente hay obligación de solicitar un ISBN para obtener el depósito legal de una monografía publicada en España?",
+      "options": [
+        "No hay ninguna obligación de solicitar un ISBN para obtener el Depósito Legal.",
+        "Sí, hay obligación de solicitar un ISBN para obtener el Depósito Legal.",
+        "El ISBN es obligatorio para publicaciones editadas en España.",
+        "El ISBN no es compatible con el Depósito legal."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 94. Respuesta validada por la plantilla oficial: No hay ninguna obligación de solicitar un ISBN para obtener el Depósito Legal.. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q094",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "No hay ninguna obligación de solicitar un ISBN para obtener el Depósito Legal."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-valencia-c1-2025-q097-b900cb4b525f",
+      "topicId": "uah-bib-t07-contenido",
+      "question": "La Ley 31/1995, de 8 de noviembre, de prevención de riesgos laborales:",
+      "options": [
+        "No es de aplicación a los funcionarios, tan sólo al personal laboral al servicio de las administraciones públicas.",
+        "Constituye legislación laboral, y por tanto sólo se aplica al personal contratado, no así al funcionario.",
+        "Se aplica al personal funcionario de las Administraciones Públicas si la Junta de Personal no se opusiera de forma expresa.",
+        "No solamente posee el carácter de legislación laboral, sino que constituye, en sus aspectos fundamentales, norma básica del régimen estatutario de los funcionarios públicos."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universitat de València 2025 - Auxiliar de Archivos y Bibliotecas C1, pregunta 97. Respuesta validada por la plantilla oficial: No solamente posee el carácter de legislación laboral, sino que constituye, en sus aspectos fundamentales, norma básica del régimen estatutario de los funcionarios públicos.. Clasificada como Tema 7 (Prevención de riesgos laborales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "valencia-c1-2025#q097",
+        "path": "data/general/07_Plan-de-Prevencion_UAH.md",
+        "highlightText": "No solamente posee el carácter de legislación laboral, sino que constituye, en sus aspectos fundamentales, norma básica del régimen estatutario de los funcionarios públicos."
+      },
+      "tags": [
+        "examen-oficial",
+        "valencia-c1-2025",
+        "uah-tema-007",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q001-ddcb564022aa",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "La autonomía universitaria garantiza la libertad de cátedra del profesorado, > que se manifiesta en:",
+      "options": [
+        "La autonomía financiera",
+        "Sólo la transferencia de resultados de las investigaciones",
+        "El estudio",
+        "La gestión administrativa de los recursos de l+D+i"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 1. Respuesta validada por la plantilla oficial: El estudio. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q001",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "El estudio"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q002-436deea0384b",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 2 de la Ley Orgánica 2/2023, de 22 de marzo, di cuál de las siguientes afirmaciones es correcta:",
+      "options": [
+        "El sistema universitario presta y garantiza el servicio público de la educación profesional de segundo grado mediante la docencia, la investigación y la transferencia del conocimiento.",
+        "El sistema universitario presta y garantiza el servicio público de la educación superior universitaria mediante la docencia, la investigación y la transferencia del conocimiento.",
+        "El sistema universitario presta y garantiza el servicio público de la educación en todos sus niveles y grados mediante la docencia, la investigación y la transferencia del conocimiento.",
+        "El sistema universitario presta y garantiza el servicio público de la educación primaria y secundaria mediante la docencia, la investigación y la transferencia del conocimiento."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 2. Respuesta validada por la plantilla oficial: El sistema universitario presta y garantiza el servicio público de la educación superior universitaria mediante la docencia, la investigación y la transferencia del conocimiento.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q002",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "El sistema universitario presta y garantiza el servicio público de la educación superior universitaria mediante la docencia, la investigación y la transferencia del conocimiento."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q004-ad9e2c8d12b2",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 43 de la Ley Orgánica del Sistema Universitario, las universidades contarán con unidades de:",
+      "options": [
+        "Igualdad y de diversidad, que se podrán constituir siempre de forma separada.",
+        "De defensoría universitaria y de inspección de servicios.",
+        "De servicios de salud y acompañamiento psicológico y pedagógico y servicios de orientación profesional, a los cuales solo se les dota con recursos humanos.",
+        "De servicios de salud y acompañamiento psicológico y pedagógico y servicios de orientación profesional, a los cuales solo se les dota con recursos económicos."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 4. Respuesta validada por la plantilla oficial: De defensoría universitaria y de inspección de servicios.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q004",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "De defensoría universitaria y de inspección de servicios."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q005-5244f8d00b92",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 40 de la Ley Orgánica 2/2023, de 22 de marzo, las universidades podrán estructurarse, según lo determinen sus Estatutos, en",
+      "options": [
+        "Campus, facultades, escuelas, departamentos, institutos universitarios de investigación, escuelas de doctorado o en otros centros o estructuras necesarios para el desarrollo de las funciones que le son propias",
+        "Campus, facultades, escuelas, departamentos, institutos universitarios de investigación, escuelas de doctorado y centros propios.",
+        "Campus, facultades, escuelas, departamentos, institutos universitarios de investigación, escuelas de doctorado y otros centros propios o adscritos.",
+        "Campus, facultades, escuelas, departamentos, institutos universitarios de investigación y de docencia, escuelas de doctorado y por aquellos otros centros necesarios para el desempeño de sus funciones."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 5. Respuesta validada por la plantilla oficial: Campus, facultades, escuelas, departamentos, institutos universitarios de investigación, escuelas de doctorado o en otros centros o estructuras necesarios para el desarrollo de las funciones que le son propias. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q005",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Campus, facultades, escuelas, departamentos, institutos universitarios de investigación, escuelas de doctorado o en otros centros o estructuras necesarios para el desarrollo de las funciones que le son propias"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q008-622f1f9e8373",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 57.21 de los Estatutos de la UCA, la autorización de gastos y la ordenación de pagos corresponde al:",
+      "options": [
+        "Gerente",
+        "Rector",
+        "Secretario del Consejo Social",
+        "Vicegerente de Asuntos Económicos"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 8. Respuesta validada por la plantilla oficial: Rector. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q008",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Rector"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q011-d6322075339a",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "¿Quién tiene la competencia de organización del trabajo según el artículo 13 del IV Convenio Colectivo del Personal laboral de las Universidades Públicas de Andalucía?",
+      "options": [
+        "El Rector de cada Universidad",
+        "Los representantes de los trabajadores",
+        "Las Gerencias de las Universidades",
+        "Los Directores de los distintos Servicios"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 11. Respuesta validada por la plantilla oficial: Las Gerencias de las Universidades. Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q011",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "Las Gerencias de las Universidades"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-002",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q012-cf4e7ddc32dd",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "Según el artículo 19 del IV Convenio Colectivo del Personal Laboral de las - Universidades Públicas de Andalucía, ¿con qué periodicidad se debe convocar concurso de traslado?",
+      "options": [
+        "Cada seis meses",
+        "Una vez al año",
+        "Cuando lo solicite el Comité de Empresa",
+        "Una vez al trimestre"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 12. Respuesta validada por la plantilla oficial: Una vez al año. Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q012",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "Una vez al año"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-002",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q013-4431df2eb8e5",
+      "topicId": "uah-bib-t07-contenido",
+      "question": "Según el artículo 43 del IV Convenio Colectivo del Personal Laboral de las Universidades Públicas de Andalucía, el órgano paritario y colegiado de representación y participación, destinado a la consulta periódica sobre las actuaciones de los centros de trabajo en materia de prevención de riesgos laborales es:",
+      "options": [
+        "El Comité de Seguridad y Salud",
+        "Los delegados de Prevención",
+        "El Servicio de Prevención",
+        "El Comité de Empresa."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 13. Respuesta validada por la plantilla oficial: El Comité de Seguridad y Salud. Clasificada como Tema 7 (Prevención de riesgos laborales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q013",
+        "path": "data/general/07_Plan-de-Prevencion_UAH.md",
+        "highlightText": "El Comité de Seguridad y Salud"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-007",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q016-51ff9b5f7d89",
+      "topicId": "uah-bib-t06-contenido",
+      "question": "De acuerdo con el artículo 51 de la Ley Orgánica 3/2007, de 22 de marzo, para la igualdad efectiva de mujeres y hombres sobre los Criterios de actuación de las Administraciones públicas en materia de igualdad, ¿cuál de las siguientes acciones deben llevar a cabo las Administraciones en el ámbito de sus competencias?",
+      "options": [
+        "Garantizar que todas las ofertas de empleo público sean exclusivamente para mujeres subrepresentadas en el sector",
+        "Derogar toda normativa que mencione el género o el sexo en los procedimientos de acceso y promoción.",
+        "Promover la presencia equilibrada de mujeres y hombres en los órganos de selección y valoración.",
+        "Priorizar la contratación de mujeres en todas las categorías profesionales para alcanzar la paridad inmediata."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 16. Respuesta validada por la plantilla oficial: Promover la presencia equilibrada de mujeres y hombres en los órganos de selección y valoración.. Clasificada como Tema 6 (Igualdad) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q016",
+        "path": "data/general/06_Ley_Organica_3_2007_de_22_de_marzo_para_la_igualdad_efectiva_de_mujeres_y_hombres.md",
+        "highlightText": "Promover la presencia equilibrada de mujeres y hombres en los órganos de selección y valoración."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-006",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q017-329d6abd65a1",
+      "topicId": "uah-bib-t06-contenido",
+      "question": "De acuerdo con el artículo 6.2 de la Ley Orgánica 3/2007, de 22 de marzo, para la igualdad efectiva de mujeres y hombres, la discriminación indirecta por razón de sexo se caracteriza tgóricamente por.",
+      "options": [
+        "Una disposición, criterio o práctica aparentemente neutros que pone a personas de un sexo en desventaja particular respecto al otro.",
+        "La orden de tratar a una persona de un sexo de manera menos favorable que a otra en situación comparable.",
+        "La situación en que una persona es tratada de manera menos favorable que otra en atención a su sexo, sin justificación",
+        "Una disposición, criterio o práctica que es intencionalmente desfavorable para un sexo específico."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 17. Respuesta validada por la plantilla oficial: Una disposición, criterio o práctica aparentemente neutros que pone a personas de un sexo en desventaja particular respecto al otro.. Clasificada como Tema 6 (Igualdad) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q017",
+        "path": "data/general/06_Ley_Organica_3_2007_de_22_de_marzo_para_la_igualdad_efectiva_de_mujeres_y_hombres.md",
+        "highlightText": "Una disposición, criterio o práctica aparentemente neutros que pone a personas de un sexo en desventaja particular respecto al otro."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-006",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q019-2ee3b72d2ff5",
+      "topicId": "uah-bib-t08-contenido",
+      "question": "Según el Código Peñalver, se entiende por código ético:",
+      "options": [
+        "El modelo que debiera inspirar la conducta de los miembros de la UCA.",
+        "El modelo que debiera inspirar la conducta de toda la ciudadanía",
+        "Un documento vivo y dinámico, abierto a una permanente respuesta a los posibles nuevos requerimientos sociales.",
+        "Un documento donde se tomen medidas adecuadas para solucionar de modo efectivo los conflictos de intereses."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 19. Respuesta validada por la plantilla oficial: El modelo que debiera inspirar la conducta de los miembros de la UCA.. Clasificada como Tema 8 (Código ético) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q019",
+        "path": "data/general/08_codigo-etico-general-UAH.md",
+        "highlightText": "El modelo que debiera inspirar la conducta de los miembros de la UCA."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-008",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q021-4aca38849613",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "¿Cuál es el propósito fundamental de la Biblioteca de la Universidad de Cádiz según la misión establecida en el Sistema de Gestión de Calidad?",
+      "options": [
+        "Generar ingresos económicos a través de la venta de servicios bibliográficos.",
+        "Colaborar en la consecución de los objetivos de la Universidad mediante la difusión de la información, así como a través de la gestión de colecciones, servicios y espacios que apoyen el aprendizaje, la investigación y la transferencia de conocimiento.",
+        "Sustituir los servicios de otras bibliotecas públicas de Cádiz.",
+        "Establecer únicamente horarios de atención al público como sala de estudios para los alumnos.."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 21. Respuesta validada por la plantilla oficial: Colaborar en la consecución de los objetivos de la Universidad mediante la difusión de la información, así como a través de la gestión de colecciones, servicios y espacios que apoyen el aprendizaje, la investigación y la transferencia de conocimiento.. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q021",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "Colaborar en la consecución de los objetivos de la Universidad mediante la difusión de la información, así como a través de la gestión de colecciones, servicios y espacios que apoyen el aprendizaje, la investigación y la transferencia de conocimiento."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q022-26467b1774e0",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Qué ventaja ofrece Koha al ser un software de código abierto?",
+      "options": [
+        "Es únicamente accesible para desarrolladores informáticos.",
+        "No puede ser modificado según las necesidades de cada biblioteca.",
+        "Permite la personalización según necesidades específicas y no implica costes de licencia propietaria.",
+        "Funciona solo sin conexión a internet."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 22. Respuesta validada por la plantilla oficial: Permite la personalización según necesidades específicas y no implica costes de licencia propietaria.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q022",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Permite la personalización según necesidades específicas y no implica costes de licencia propietaria."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q023-43c249504420",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Cómo puede consultar un usuario del Campus de Jerez los libros ubicados en la Biblioteca del Campus de Cádiz?",
+      "options": [
+        "No puede acceder desde otros campus que no sea Cádiz.",
+        "Solo a través de una solicitud física al personal de biblioteca.",
+        "Mediante acceso en línea al catálogo de la Biblioteca de la UCA, Koha, desde cualquier ubicación.",
+        "Unicamente tras solicitarlo personalmente a un profesor de su campus."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 23. Respuesta validada por la plantilla oficial: Mediante acceso en línea al catálogo de la Biblioteca de la UCA, Koha, desde cualquier ubicación.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q023",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Mediante acceso en línea al catálogo de la Biblioteca de la UCA, Koha, desde cualquier ubicación."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q024-f9bc181a292a",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Cuáles son los canales principales de atención al usuario en la Biblioteca de la UCA?",
+      "options": [
+        "Solo atención presencial en mostrador.",
+        "Chat, Correo electrónico, Whatsapp, Teléfono y Atención presencial directa del personal bibliotecario.",
+        "Únicamente por correo ordinario.",
+        "Solo mediante solicitudes por escrito formales y registradas a través del registro general de la UCA."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 24. Respuesta validada por la plantilla oficial: Chat, Correo electrónico, Whatsapp, Teléfono y Atención presencial directa del personal bibliotecario.. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q024",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Chat, Correo electrónico, Whatsapp, Teléfono y Atención presencial directa del personal bibliotecario."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q025-2de3da93bf41",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Qué es la \"renovación\" del préstamo de un libro en la Biblioteca de la UCA?",
+      "options": [
+        "Cambiar el libro por otro diferente.",
+        "Extender el período de préstamo del libro si éste no ha vencido y no hay reserva de otro usuario.",
+        "Devolver el libro y prestar otro inmediatamente.",
+        "Comprar una nueva copia del libro en mejores condiciones físicas."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 25. Respuesta validada por la plantilla oficial: Extender el período de préstamo del libro si éste no ha vencido y no hay reserva de otro usuario.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q025",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Extender el período de préstamo del libro si éste no ha vencido y no hay reserva de otro usuario."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q026-3a457bb24c94",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Cuál es la diferencia entre \"préstamo entre bibliotecas UCA\" y \"préstamo interbibliotecario\"?",
+      "options": [
+        "No existe diferencia; son sinónimos.",
+        "El primero posibilita el acceso a documentos de otras instituciones y el segundo la circulación interna de documentos entre campus de la UCA.",
+        "El préstamo entre bibliotecas UCA es internacional; el interbibliotecario es solo nacional.",
+        "El primero posibilita para la circulación interna de documentos entre campus de la UCA y el segundo el acceso a documentos de otras instituciones.."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 26. Respuesta validada por la plantilla oficial: El primero posibilita para la circulación interna de documentos entre campus de la UCA y el segundo el acceso a documentos de otras instituciones... Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q026",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "El primero posibilita para la circulación interna de documentos entre campus de la UCA y el segundo el acceso a documentos de otras instituciones.."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q028-a07bf4bf09c4",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Qué significa NIPO en el contexto de identificadores bibliográficos?",
+      "options": [
+        "Un código de archivo o clasificación para documentos japoneses",
+        "Un sistema internacional equivalente a ISBN",
+        "Número de Implantación de Programas Oficiales",
+        "Número de Identificación de Publicaciones Oficiales"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 28. Respuesta validada por la plantilla oficial: Número de Identificación de Publicaciones Oficiales. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q028",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "Número de Identificación de Publicaciones Oficiales"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q030-4300aad635ae",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Cuál es el propósito principal de los proyectos de digitalización en > bibliotecas y archivos?",
+      "options": [
+        "Reemplazar completamente colecciones impresas.",
+        "Preservar patrimonio bibliográfico, mejorar acceso remoto y garantizar la conservación a largo plazo de los documentos.",
+        "Reducir el número de usuarios en las bibliotecas.",
+        "Generar ingresos económicos con la venta de ebooks."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 30. Respuesta validada por la plantilla oficial: Preservar patrimonio bibliográfico, mejorar acceso remoto y garantizar la conservación a largo plazo de los documentos.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q030",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Preservar patrimonio bibliográfico, mejorar acceso remoto y garantizar la conservación a largo plazo de los documentos."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q031-32a8584cadfc",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "¿Qué son las licencias Creative Commons y cómo se aplican en recursos académicos?",
+      "options": [
+        "Licencias que prohíben cualquier uso de obras con derechos de autor.",
+        "Son licencias equivalentes al obsoleto copyright tradicional.",
+        "Solo se aplican a películas y música comerciales.",
+        "Licencias flexibles que permiten compartir y utilizar obras bajo condiciones específicas.."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 31. Respuesta validada por la plantilla oficial: Licencias flexibles que permiten compartir y utilizar obras bajo condiciones específicas... Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q031",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Licencias flexibles que permiten compartir y utilizar obras bajo condiciones específicas.."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q032-4318669bcfb0",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Cuál de estos NO es un derecho de los usuarios de la biblioteca?",
+      "options": [
+        "Recibir información y asesoramiento sobre los recursos y servicios por parte del personal de la biblioteca.",
+        "El respeto a la confidencialidad de sus datos personales y de sus transacciones conforme a la legislación vigente",
+        "Obtener los libros solicitados en préstamo a otro Campus cuando estén disponibles.",
+        "Disponer de espacios y equipamientos para la realización de actividades individuales y de grupo"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 32. Respuesta validada por la plantilla oficial: Obtener los libros solicitados en préstamo a otro Campus cuando estén disponibles.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q032",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Obtener los libros solicitados en préstamo a otro Campus cuando estén disponibles."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q033-da582d7e954f",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "Koha es un sistema desarrollado por:",
+      "options": [
+        "Bibliotecas, voluntarios y empresas",
+        "La Federación Internacional de Asociaciones e Instituciones Bibliotecarias (IFLA)",
+        "El Online Computer Library Center (OCLC)",
+        "The Horowhenua Library Trust de Nueva Zelanda"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 33. Respuesta validada por la plantilla oficial: Bibliotecas, voluntarios y empresas. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q033",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Bibliotecas, voluntarios y empresas"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q036-ee9a05ae5958",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "El sistema Bibliobook® permite: 5",
+      "options": [
+        "Consultar todo el catálogo de la Biblioteca de la UCA.",
+        "Acceder a la bibliografía recomendada de cada asignatura.",
+        "Obtener documentos de otras bibliotecas que no se encuentran en la biblioteca del usuario.",
+        "Citar correctamente la bibliografía utilizada en un trabajo académico."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 36. Respuesta validada por la plantilla oficial: Acceder a la bibliografía recomendada de cada asignatura.. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q036",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "Acceder a la bibliografía recomendada de cada asignatura."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q037-ee4c78d085c6",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Cuál de estos servicios de atención al usuario en la Biblioteca de la UCA está diseñado para atender consultas en tiempo real?.",
+      "options": [
+        "Facebook",
+        "Correo electrónico",
+        "Whatsapp",
+        "Chat"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 37. Respuesta validada por la plantilla oficial: Chat. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q037",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Chat"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q039-0ee1f6c036d8",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Cuánto tiempo puede tener en préstamo un libro un alumno que curse un Máster de la FundUca (anteriormente FUECA)?",
+      "options": [
+        "15 días",
+        "30 días",
+        "7 días",
+        "5 días"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 39. Respuesta validada por la plantilla oficial: 15 días. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q039",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "15 días"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q041-9acdf6335198",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Las salas de trabajo de las bibliotecas de la UCA pueden ser reservadas por: +.",
+      "options": [
+        "Alumnos de posgrado",
+        "PDI",
+        "Alumnos de grado y egresados",
+        "PTGAS"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 41. Respuesta validada por la plantilla oficial: Alumnos de posgrado. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q041",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Alumnos de posgrado"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q042-3ecd04f08f3c",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Cuál de los siguientes documentos se puede solicitar por Préstamo Interbibliotecario?",
+      "options": [
+        "Comunicaciones de Congresos",
+        "Libros electrónicos",
+        "Obras de referencia",
+        "Fasciculos de revista"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 42. Respuesta validada por la plantilla oficial: Comunicaciones de Congresos. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q042",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Comunicaciones de Congresos"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q043-051fc5682b70",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Cuál de estas bibliotecas de la UCA es punto de servicio del préstamo interbibliotecario?.",
+      "options": [
+        "La Biblioteca del Campus de Puerto Real",
+        "La Biblioteca de Ciencias Sociales y Jurídicas",
+        "La Biblioteca de Humanidades",
+        "La Biblioteca del Campus de Jerez"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 43. Respuesta validada por la plantilla oficial: La Biblioteca de Humanidades. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q043",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "La Biblioteca de Humanidades"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q046-514f6cf3b59b",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Qué ofrece el BUSCAdor Summon para conectar los resultados de la búsqueda con la docencia universitaria?",
+      "options": [
+        "Filtrar la bibliografía recomendada por asignatura y profesor",
+        "Filtrar la bibliografía recomendada por grado y asignatura",
+        "Filtrar material docente del campus virtual",
+        "Filtrar material docente del portal de producción científica ul"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 46. Respuesta validada por la plantilla oficial: Filtrar la bibliografía recomendada por asignatura y profesor. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q046",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Filtrar la bibliografía recomendada por asignatura y profesor"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q048-010df29531c7",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Qué nuevo prefijo (bloque de ISBN) se le ha otorgado recientemente a la Agencia del ISBN en España?",
+      "options": [
+        "979-14-",
+        "978-84-",
+        "979-10-",
+        "979-13-."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 48. Respuesta validada por la plantilla oficial: 979-13-.. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q048",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "979-13-."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-014",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q049-17db94d416d5",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "En la CDU, el auxiliar correspondiente a \"diccionarios\" es:",
+      "options": [
+        "(091)",
+        "(03)",
+        "(038)",
+        "(041)"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 49. Respuesta validada por la plantilla oficial: (038). Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q049",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "(038)"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q051-53fdfdfaa7d7",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "En sus recomendaciones técnicas para la digitalización de documentos, la Junta de Andalucía indica en su punto 5.1 que las reproducciones digitales de alta calidad se realizarán con fines de preservación en formato:",
+      "options": [
+        "PNG",
+        "PDF",
+        "JPEG",
+        "TIFF"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 51. Respuesta validada por la plantilla oficial: TIFF. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q051",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "TIFF"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-012",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q052-526748e7ad9b",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿En qué modelo de publicación en acceso abierto se enmarca RODIN?",
+      "options": [
+        "Vía dorada",
+        "Vía verde",
+        "Vía diamante",
+        "Vía híbrida"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 52. Respuesta validada por la plantilla oficial: Vía verde. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q052",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Vía verde"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q053-1d945f7cb66d",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "¿Qué modalidad de licencia Creative Commons se recomienda desde RODIN?",
+      "options": [
+        "Reconocimiento — No comercial — Sin obra derivada",
+        "Reconocimiento — No comercial — Compartir igual",
+        "Reconocimiento — Sin obra derivada",
+        "Reconocimiento — Compartir igual"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 53. Respuesta validada por la plantilla oficial: Reconocimiento — No comercial — Sin obra derivada. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q053",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Reconocimiento — No comercial — Sin obra derivada"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q054-8ed78ac9a355",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "¿Qué tipo de bibliotecas forman parte de REBIUN?",
+      "options": [
+        "Solo bibliotecas de ámbito univérsitario público",
+        "Bibliotecas públicas",
+        "Bibliotecas del CSIC",
+        "Bibliotecas de ámbito universitario público y privado más bibliotecas del CSIC"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 54. Respuesta validada por la plantilla oficial: Bibliotecas de ámbito universitario público y privado más bibliotecas del CSIC. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q054",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "Bibliotecas de ámbito universitario público y privado más bibliotecas del CSIC"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q055-30a2aa6c3ed3",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "¿Qué norma española regula la propiedad intelectual de las creaciones originales literarias, artísticas o científicas?",
+      "options": [
+        "Ley orgánica 15/1999",
+        "Real Decreto 111/1986",
+        "Real Decreto Legislativo 1/1996",
+        "Ley 30/1992"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 55. Respuesta validada por la plantilla oficial: Real Decreto Legislativo 1/1996. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q055",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Real Decreto Legislativo 1/1996"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q056-9bd183a9558c",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál es la característica principal del BUSCAdor Summon de la Biblioteca de la Universidad de Cádiz?",
+      "options": [
+        "Que únicamente permite localizar los libros y revistas impresas del catálogo tradicional.",
+        "Que realiza búsquedas sólo en bases de datos suscritas por la Biblioteca de la UCA.",
+        "Que ofrece resultados exclusivos del repositorio institucional RODIN sin incluir otros recursos.",
+        "Que ofrece resultados del catálogo tradicional, bases de datos suscritas por la Biblioteca y de acceso abierto, del repositorio institucional RODIN, de la plataforma de préstamo de libros electrónicos, etc."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 56. Respuesta validada por la plantilla oficial: Que ofrece resultados del catálogo tradicional, bases de datos suscritas por la Biblioteca y de acceso abierto, del repositorio institucional RODIN, de la plataforma de préstamo de libros electrónicos, etc.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q056",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Que ofrece resultados del catálogo tradicional, bases de datos suscritas por la Biblioteca y de acceso abierto, del repositorio institucional RODIN, de la plataforma de préstamo de libros electrónicos, etc."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q057-075b038e6773",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "En el servicio de préstamo de libros electrónicos Xebook de la Biblioteca de la Universidad de Cádiz, ¿cuántos ejemplares puede tener prestados ae simultaneamente un usuario?",
+      "options": [
+        "1 ejemplar",
+        "3 ejemplares",
+        "5 ejemplares",
+        "10 ejemplares"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 57. Respuesta validada por la plantilla oficial: 3 ejemplares. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q057",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "3 ejemplares"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q058-4a416db44e75",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "¿Cómo se denomina el número auxiliar común de lugar en la CDU?",
+      "options": [
+        ": (dos puntos)",
+        "= (igual)",
+        "(1/9) (paréntesis)",
+        "+ (signo más)"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 58. Respuesta validada por la plantilla oficial: (1/9) (paréntesis). Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q058",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "(1/9) (paréntesis)"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q060-db16e15c6a17",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Según la normativa de la UCA, ¿qué sucede si una sala de trabajo reservada no se utiliza en los primeros 15 minutos?",
+      "options": [
+        "La reserva se prorroga automáticamente otros 15 minutos.",
+        "La sala queda bloqueada para su uso el resto del día.",
+        "El personal de la biblioteca puede cancelar la reserva y liberar el espacio.",
+        "Se suspende el derecho de reserva al usuario"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 60. Respuesta validada por la plantilla oficial: El personal de la biblioteca puede cancelar la reserva y liberar el espacio.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q060",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "El personal de la biblioteca puede cancelar la reserva y liberar el espacio."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q061-3d066af99417",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "¿De qué Vicerrectorado depende actualmente la Biblioteca de la UCA?",
+      "options": [
+        "Vicerrectorado de Investigación y Transferencia",
+        "Vicerrectorado de Sostenibilidad y Cultura",
+        "Vicerrectorado de Estudiantes",
+        "Vicerrectorado de Transformación para la Universidad Digital"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 61. Respuesta validada por la plantilla oficial: Vicerrectorado de Investigación y Transferencia. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q061",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Vicerrectorado de Investigación y Transferencia"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q062-c86e5f3229e2",
+      "topicId": "uah-bib-t11-contenido",
+      "question": "La Biblioteca de la Universidad de Cádiz dispone de un sistema de monitorización de puestos de lectura, ¿en qué campus se puede consultar en línea la ocupación de puestos en tiempo real?",
+      "options": [
+        "En el Campus de Cádiz, de Puerto Real y Bahía de Algeciras",
+        "En los Campus de Puerto Real, de Jerez y Bahía de Algeciras",
+        "En el Campus de Cádiz, de Jerez y Bahia de Algeciras",
+        "En todos los Campus"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 62. Respuesta validada por la plantilla oficial: En los Campus de Puerto Real, de Jerez y Bahía de Algeciras. Clasificada como Tema 11 (Organización espacial y equipamiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q062",
+        "path": "data/uah-bibliotecas-2025/referencias/11_organizacion_espacial_equipamiento_buah.md",
+        "highlightText": "En los Campus de Puerto Real, de Jerez y Bahía de Algeciras"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-011",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q066-1123e4180f00",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "¿Cuál sería la CDU correcta para un libro de Historia Moderna de España?",
+      "options": [
+        "946.0\"14/18\"",
+        "946.0\"16/18\"",
+        "946.0\"15/18\"",
+        "946.0°14/16\""
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 66. Respuesta validada por la plantilla oficial: 946.0\"14/18\". Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q066",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "946.0\"14/18\""
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-015",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q069-bc5c1b81617d",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "Según la Carta de Servicios de la Biblioteca de la UCA, ¿qué compromiso adquiere la Biblioteca respecto a la inversión en fondos bibliográficos?",
+      "options": [
+        "Invertir al menos un 50 % del presupuesto en libros impresos.",
+        "Destinar un 30 % del presupuesto exclusivamente a recursos electrónicos.",
+        "Invertir únicamente en bibliografía recomendada por el profesorado.",
+        "Invertir al menos un 70 % del presupuesto de la Biblioteca en la adquisición de fondos bibliográficos."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 69. Respuesta validada por la plantilla oficial: Invertir al menos un 70 % del presupuesto de la Biblioteca en la adquisición de fondos bibliográficos.. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q069",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Invertir al menos un 70 % del presupuesto de la Biblioteca en la adquisición de fondos bibliográficos."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q070-503411c30ea8",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Qué es el Espacio para la Igualdad de la Biblioteca UCA?",
+      "options": [
+        "Una colección de comics sobre la temática de la igualdad",
+        "Espacios reservados en las Bibliotecas para celebración de actos sobre asuntos relacionados con la igualdad en el Campus Bahía de Algeciras.",
+        "Una colección bibliográfica ubicada en la Biblioteca de Humanidades sobre la temática de la igualdad.",
+        "Una colección bibliográfica en una zona reservable de la Biblioteca del Campus de Jerez para celebración de actos sobre asuntos relacionados con la igualdad."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 70. Respuesta validada por la plantilla oficial: Una colección bibliográfica en una zona reservable de la Biblioteca del Campus de Jerez para celebración de actos sobre asuntos relacionados con la igualdad.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q070",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Una colección bibliográfica en una zona reservable de la Biblioteca del Campus de Jerez para celebración de actos sobre asuntos relacionados con la igualdad."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q073-c332bc818435",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "La Biblioteca UCA oferta, entre sus cursos de formación, dos cursos específicos sobre estos Gestores de Referencia Bibliográficos:",
+      "options": [
+        "Refworks y Endnote",
+        "Mendeley y Refworks",
+        "Refworks y JabRef",
+        "Mendeley y Zotero"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 73. Respuesta validada por la plantilla oficial: Mendeley y Zotero. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q073",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Mendeley y Zotero"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q078-edb8904bc19b",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "Respecto a las quejas y reclamaciones, ¿cuál es el derecho del usuario que figura en la Carta de Servicios del Archivo de la UCA?",
+      "options": [
+        "Presentar quejas solo a través del BAU",
+        "Presentar quejas, reclamaciones y sugerencias y recibir respuesta",
+        "Recibir compensación económica si la queja es estimada",
+        "Presentar quejas solo de forma presencial"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 78. Respuesta validada por la plantilla oficial: Presentar quejas, reclamaciones y sugerencias y recibir respuesta. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q078",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "Presentar quejas, reclamaciones y sugerencias y recibir respuesta"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q080-b6aaa02715fe",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "¿Qué órgano universitario aprobó el Reglamento del Archivo de la Universidad de Cádiz, y en qué fecha?",
+      "options": [
+        "El Rector, el 1 de diciembre de 2023",
+        "La Junta Consultiva, el 10 de julio de 2025",
+        "El Claustro Universitario, el 7 de julio de 2020",
+        "Acuerdo de Consejo de Gobierno de 1 de diciembre de 2023"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 80. Respuesta validada por la plantilla oficial: Acuerdo de Consejo de Gobierno de 1 de diciembre de 2023. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q080",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Acuerdo de Consejo de Gobierno de 1 de diciembre de 2023"
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-cadiz-c1-2025-q089-fb3cd962f285",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Respecto a las tesis depositadas en el Archivo de la UCA y que son i accesibles a través del catálogo de los fondos del Archivo, ¿cuál es la norma que se aplica al acceso de estos documentos?",
+      "options": [
+        "El acceso al catálogo es público y sí requiere identificación previa de usuario.",
+        "El usuario puede solicitar el préstamo de la tesis por un período de 7 días.",
+        "Las tesis doctorales inéditas son suministradas a través del Servicio de Préstamo Interbibliotecario.",
+        "El acceso al catálogo es público y no requiere identificación, pero no se realizará el préstamo de las tesis."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cádiz 2025 - Técnico Auxiliar Biblioteca, Archivo y Museo, pregunta 89. Respuesta validada por la plantilla oficial: El acceso al catálogo es público y no requiere identificación, pero no se realizará el préstamo de las tesis.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cadiz-c1-2025#q089",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "El acceso al catálogo es público y no requiere identificación, pero no se realizará el préstamo de las tesis."
+      },
+      "tags": [
+        "examen-oficial",
+        "cadiz-c1-2025",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q006-88ee92c9893b",
+      "topicId": "uah-bib-t01-contenido",
+      "question": "Según establece la Constitución Española el estado de sitio:",
+      "options": [
+        "Será declarado por el Gobierno mediante decreto acordado en Consejo de Ministros dando cuenta al Congreso de los Diputados.",
+        "Será declarado por la mayoría absoluta del Congreso de los Diputados y del Senado en sesión conjunta de ambas cámaras.",
+        "Será declarado por el Gobierno mediante decreto acordado en Consejo de Ministros, previa autorización del Congreso de los Diputados.",
+        "Será declarado por la mayoría absoluta del Congreso de los Diputados."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 6. Respuesta validada por la plantilla oficial: Será declarado por la mayoría absoluta del Congreso de los Diputados.. Clasificada como Tema 1 (Constitución Española) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q006",
+        "path": "data/general/01_constitucion_espanola_1978.md",
+        "highlightText": "Será declarado por la mayoría absoluta del Congreso de los Diputados."
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-001",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q020-0dd47b618a2a",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según la Ley Orgánica 2/2023, del Sistema Universitario, en el ámbito de la movilidad internacional de la comunidad universitaria, SEÑALE LA FALSA:",
+      "options": [
+        "El Gobierno promoverá programas de movilidad e intercambio del del personal técnico, de gestión y de administración y servicios.",
+        "El Ministerio de Universidades, promoverá la presencia de universidades y las distintas instancias del sistema universitario español en los órganos y foros de representación nacional universitaria.",
+        "El Ministerio de Universidades, promoverá los programas de movilidad financiados con fondos de la Unión Europea, con particular referencia al programa Erasmus+.",
+        "El Ministerio de Universidades, promoverá programas de movilidad que cuenten con financiación pública. ercicio de la fase de oposición de las pruebas selectivas convocadas por n rectoral de 8 de abril de 2024 (BOE 16 de abril). Plazas: LBIB0032 y"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 20. Respuesta validada por la plantilla oficial: El Ministerio de Universidades, promoverá la presencia de universidades y las distintas instancias del sistema universitario español en los órganos y foros de representación nacional universitaria.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q020",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "El Ministerio de Universidades, promoverá la presencia de universidades y las distintas instancias del sistema universitario español en los órganos y foros de representación nacional universitaria."
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q023-cd8d0b663dbb",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según el artículo 10 de los Estatutos de la UNED, la Comisión de Metodología y Docencia:",
+      "options": [
+        "Será constituida por el Claustro Universitario, presidida por el rector e integrada por los decanos y directores de escuela.",
+        "Será constituida por el Consejo de Gobierno, presidida por el vicerrector con competencia en la materia e integrada solo por profesores con vinculación permanente.",
+        "Será elegida por el Consejo de Gobierno por la mayoría absoluta de sus miembros cada cuatro años y solo estará compuesta por profesores con vinculación permanente.",
+        "Podrá constituir una comisión permanente, integrada por el vicerrector, que la presidirá y por un número de miembros que garantice la representación de todos los sectores."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 23. Respuesta validada por la plantilla oficial: Podrá constituir una comisión permanente, integrada por el vicerrector, que la presidirá y por un número de miembros que garantice la representación de todos los sectores.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q023",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Podrá constituir una comisión permanente, integrada por el vicerrector, que la presidirá y por un número de miembros que garantice la representación de todos los sectores."
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q038-d2ba8b192187",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "El formato MARC fue desarrollado en la Biblioteca del Congreso por:",
+      "options": [
+        "Radia Perlman",
+        "Peter Mark",
+        "Henriette Avram",
+        "Paul Otlet."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 38. Respuesta validada por la plantilla oficial: Henriette Avram. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q038",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Henriette Avram"
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q040-36402cdfaaea",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "La Biblioteca del Campus Norte de la UNED:",
+      "options": [
+        "Fue Inaugurada en 2012 y es resultado de la fusión de las Bibliotecas de Ingenierías, Psicologia-IUED y del fondo de la Facultad de Educación. percicio de la fase de oposición de las pruebas selectivas convocadas por 111114 1]bn rectoral de 8 de abril de 2024 (BOE 16 de abril). Plazas: LBIB0032 y p3.",
+        "Fue Inaugurada en 2012 y es resultado de la fusión de las Bibliotecas de Humanidades, Psicologia-IUED y del fondo de la Facultad de Educación.",
+        "Fue Inaugurada en 2014 y es resultado de la fusión de las Bibliotecas de Humanidades, de Ciencias, Biblioteca de Ciencias Sociales y Biblioteca de Ingeniería.",
+        "Fue Inaugurada en 2014 y es resultado de la fusión de las Bibliotecas de Ciencias Sociales, Biblioteca de Ingeniería y del fondo de la Facultad de Educación."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 40. Respuesta validada por la plantilla oficial: Fue Inaugurada en 2012 y es resultado de la fusión de las Bibliotecas de Ingenierías, Psicologia-IUED y del fondo de la Facultad de Educación. percicio de la fase de oposición de las pruebas selectivas convocadas por 111114 1]bn rectoral de 8 de abril de 2024 (BOE 16 de abril). Plazas: LBIB0032 y p3.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q040",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Fue Inaugurada en 2012 y es resultado de la fusión de las Bibliotecas de Ingenierías, Psicologia-IUED y del fondo de la Facultad de Educación. percicio de la fase de oposición de las pruebas selectivas convocadas por 111114 1]bn rectoral de 8 de abril de 2024 (BOE 16 de abril). Plazas: LBIB0032 y p3."
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q041-6f2b72abe016",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Las diferentes salas y espacios de la Biblioteca de Campus Norte de la UNED para trabajar en equipo, realizar seminarios y tutorías con alumnos y proyectos de investigación:",
+      "options": [
+        "Están destinadas a los miembros de la Comunidad Universitaria de la UNED y para reservarlas hay que apuntarse en las listas que se encuentran en las distintas salas.",
+        "Están destinadas a cualquier estudiante universitario y para reservarlas hay que consultar previamente su disponibilidad en el calendario y cumplimentar el formulario de solicitud que se encuentra en la web de la biblioteca.",
+        "Están destinadas a los miembros de la Comunidad Universitaria de la UNED y para reservarlas hay que consultar en la web de la biblioteca su disponibilidad en el calendario y cumplimentar el formulario de solicitud.",
+        "Son de uso libre y pueden usarlas cualquier persona que acceda a la biblioteca."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 41. Respuesta validada por la plantilla oficial: Están destinadas a los miembros de la Comunidad Universitaria de la UNED y para reservarlas hay que consultar en la web de la biblioteca su disponibilidad en el calendario y cumplimentar el formulario de solicitud.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q041",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Están destinadas a los miembros de la Comunidad Universitaria de la UNED y para reservarlas hay que consultar en la web de la biblioteca su disponibilidad en el calendario y cumplimentar el formulario de solicitud."
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-018",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q045-a7d4fe43003c",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "Según las \"Normas y directrices para bibliotecas universitarias y científicas\" elaboradas por REBIUN, el presupuesto ordinario asignado a la Biblioteca Universitaria debe suponer:",
+      "options": [
+        "Como mínimo el 10% del presupuesto total ordinario de la universidad.",
+        "El 20 % del presupuesto total ordinario de la universidad.",
+        "Como mínimo el 5 % del presupuesto total ordinario de la universidad.",
+        "El 15 % del presupuesto total ordinario de la universidad."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 45. Respuesta validada por la plantilla oficial: Como mínimo el 5 % del presupuesto total ordinario de la universidad.. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q045",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "Como mínimo el 5 % del presupuesto total ordinario de la universidad."
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-010",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q048-96908159b8a4",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "PREMIS es un esquema de:",
+      "options": [
+        "Metadatos técnico.",
+        "Metadatos descriptivo.",
+        "Metadatos de preservación.",
+        "Metadatos estructural."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 48. Respuesta validada por la plantilla oficial: Metadatos de preservación.. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q048",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "Metadatos de preservación."
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-012",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q057-f856b554b196",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "El formato MARC 21 cuyo fin es proporcionar información sobre cada ítem e identificar cada uno de los documentos que constituyen el fondo con datos como la signatura, colección, número de copia, etc. es:",
+      "options": [
+        "MARC 21 para registros bibliográficos",
+        "MARC 21 para registros de clasificación",
+        "MARC 21 para registros de fondos y localizaciones",
+        "MARC 21 para información de la comunidad"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 57. Respuesta validada por la plantilla oficial: MARC 21 para registros de fondos y localizaciones. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q057",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "MARC 21 para registros de fondos y localizaciones"
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q058-f287949c0f4c",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "Las Reglas de Catalogación Españolas vigentes se redactaron teniendo en cuenta:",
+      "options": [
+        "Las ISNM",
+        "Las AACR2",
+        "Las ISAD",
+        "Las GNU"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 58. Respuesta validada por la plantilla oficial: Las AACR2. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q058",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Las AACR2"
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uned-aux-2024-q059-e5a2fabbb99b",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "El área 5 de las ISBD corresponde a la de:",
+      "options": [
+        "Edición cans oa Ge",
+        "Publicacién. IP",
+        "Descripción física",
+        "Serie"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: UNED 2024 - Auxiliar de Biblioteca, pregunta 59. Respuesta validada por la plantilla oficial: Descripción física. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uned-aux-2024#q059",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Descripción física"
+      },
+      "tags": [
+        "examen-oficial",
+        "uned-aux-2024",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q001-c8ac6c822243",
+      "topicId": "uah-bib-t01-contenido",
+      "question": "La Constitución española reconoce el derecho de reunión pacífica y sin armas. El ejercicio de este derecho:.",
+      "options": [
+        "Requerira autorización de la autoridad correspondiente.",
+        "Solo se permite a miembros de asociaciones réconocidas.",
+        "Requiere siempre comunicación previa a la autoridad.",
+        "No necesitará autorización previa."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 1. Respuesta validada por la plantilla oficial: No necesitará autorización previa.. Clasificada como Tema 1 (Constitución Española) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q001",
+        "path": "data/general/01_constitucion_espanola_1978.md",
+        "highlightText": "No necesitará autorización previa."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-001",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q002-c463145b29c2",
+      "topicId": "uah-bib-t01-contenido",
+      "question": "Atendiendo a lo establecido en la Constitución Española ¿cuál de las siguientes materias es competencia exclusiva del Estado?",
+      "options": [
+        "Legislación sobre propiedad intelectual e industrial.",
+        "Artesanía.",
+        "Montes y aprovechamientos forestales.",
+        "Sanidad e higiene."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 2. Respuesta validada por la plantilla oficial: Legislación sobre propiedad intelectual e industrial.. Clasificada como Tema 1 (Constitución Española) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q002",
+        "path": "data/general/01_constitucion_espanola_1978.md",
+        "highlightText": "Legislación sobre propiedad intelectual e industrial."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-001",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q006-6b0038f3cb60",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según la LO 2/2023 del Sistema Universitario, el máximo órgano de gobierno de la universidad pública es:",
+      "options": [
+        "Elrectoro la rectora.",
+        "Elrectoro rectora y el Equipo de Gobierno.",
+        "El Consejo de Gobierno.",
+        "El Claustro Universitario."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 6. Respuesta validada por la plantilla oficial: El Consejo de Gobierno.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q006",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "El Consejo de Gobierno."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q007-b5024d0f6924",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según establece la LOSU, el personal docente e investigador debe depositar una copia de la versión final aceptada para publicación y los datos asociados a la misma:",
+      "options": [
+        "Enrepositorios de acceso abierto de forma simultánea a la fecha de publicación.",
+        "Enrepositorios de acceso abierto con un plazo de embargo que no excederá de los seis meses.",
+        "Enrepositorios internacionales en un plazo no superior a un año desde la fecha de publicación.",
+        "Enrepositorios de las editoriales que hayan aceptado los trabajos."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 7. Respuesta validada por la plantilla oficial: Enrepositorios de acceso abierto de forma simultánea a la fecha de publicación.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q007",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Enrepositorios de acceso abierto de forma simultánea a la fecha de publicación."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q009-e96dd618eb4c",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Los órganos aseguramiento de la calidad del sistema universitario español son Pruebas selectivas para el ingreso en la Escala Auxiliar de U C | U nive rsidad Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de Ca ntabri a, de 7 de julio de 2025 (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)",
+      "options": [
+        "La Agencia Nacional de Evaluación de la Calidad y Acreditación (ANECA) exclusivamente para todo el ámbito territorial español. ¢",
+        "La ANECA y, en su correspondiente ámbito territorial, las agencias de calidad de las Comunidades Autónomas inscritas en el Registro Europeo de Agencias de Aseguramiento de la Calidad en la Educación Superior.",
+        "Una agencia evaluadora independiente con experiencia en el sector universitario.",
+        "Los Servicios Internos de Garantía de Calidad de cada universidad y el Sistema Integrado de Información Universitaria (SIIU) del Ministerio de Universidades."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 9. Respuesta validada por la plantilla oficial: La ANECA y, en su correspondiente ámbito territorial, las agencias de calidad de las Comunidades Autónomas inscritas en el Registro Europeo de Agencias de Aseguramiento de la Calidad en la Educación Superior.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q009",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "La ANECA y, en su correspondiente ámbito territorial, las agencias de calidad de las Comunidades Autónomas inscritas en el Registro Europeo de Agencias de Aseguramiento de la Calidad en la Educación Superior."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q012-cd517013f7ec",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "Según el Estatuto Básico del Empleado Público, cuál de las siguientes NO es una clase de empleado público:",
+      "options": [
+        "Funcionarios interinos.",
+        "Personal laboral.",
+        "Personal eventual.",
+        "Personal de libre designación. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C | U niversidad Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 Fl, de Cantab a (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 12. Respuesta validada por la plantilla oficial: Personal de libre designación. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C | U niversidad Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 Fl, de Cantab a (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto). Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q012",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "Personal de libre designación. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C | U niversidad Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 Fl, de Cantab a (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-002",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q014-0573af0ce59d",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "¿Qué se entiende por <datos genéticos=, según el Reglamento General de Protección de Datos?",
+      "options": [
+        "Datos personales relativos a las características genéticas heredadas o adquiridas de una persona física que proporcionen una información única sobre la fisiología o la salud de esa persona, obtenidos en particular del análisis de una muestra biológica de tal persona.",
+        "Datos personales obtenidos a partir de un tratamiento técnico específico, relativos a las características físicas, fisiológicas o conductuales de una persona física que permitan o confirmen la identificación única de dicha persona, como imágenes faciales o datos dactiloscópicos.",
+        "Datos personales relativos a la salud física o mental de una persona física, incluida la prestación de servicios de atención sanitaria, que revelen información sobre su estado de salud.",
+        "Datos personales relativos a la genealogía y antecedentes familiares de una persona física que proporcionen información única sobre posibles características genéticas heredadas."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 14. Respuesta validada por la plantilla oficial: Datos personales relativos a las características genéticas heredadas o adquiridas de una persona física que proporcionen una información única sobre la fisiología o la salud de esa persona, obtenidos en particular del análisis de una muestra biológica de tal persona.. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q014",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Datos personales relativos a las características genéticas heredadas o adquiridas de una persona física que proporcionen una información única sobre la fisiología o la salud de esa persona, obtenidos en particular del análisis de una muestra biológica de tal persona."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-004",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q021-2cede75af99a",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "¿Qué sistema de gestión utiliza el catálogo colectivo de REBIUN?",
+      "options": [
+        "AbsysNET.",
+        "Digibis.",
+        "Milenium.",
+        "Virtual ILS."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 21. Respuesta validada por la plantilla oficial: AbsysNET.. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q021",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "AbsysNET."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-020",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q022-60ea15d0b4d2",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "¿Cuál de los siguientes acrónimos NO corresponde a un consorcio de Bibliotecas?",
+      "options": [
+        "BUCLE",
+        "CCPP",
+        "CBUA",
+        "CBUC"
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 22. Respuesta validada por la plantilla oficial: CCPP. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q022",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "CCPP"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-020",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q024-38b6d423568e",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Los Responsables de división de la Biblioteca de la Universidad de Cantabria dependen jerárquicamente de:",
+      "options": [
+        "La dirección. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C U n ive rsid a da Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Ca Cantabria (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)",
+        "La subdirección.",
+        "El coordinador de colecciones. 4",
+        "Elcoordinador de formación y promoción."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 24. Respuesta validada por la plantilla oficial: La dirección. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C U n ive rsid a da Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Ca Cantabria (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto). Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q024",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "La dirección. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C U n ive rsid a da Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Ca Cantabria (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q025-e795240ace82",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "Según el Reglamento de la Biblioteca de la Universidad de Cantabria ¿qué consecuencia puede tener para un usuario/a utilizar la identificación de otra persona para acceder a la Biblioteca electrónica Emilio Botín?",
+      "options": [
+        "Comunicación a las autoridades académicas de su Facultad o Escuela",
+        "Exclusión del uso de la biblioteca del Paraninfo por un periodo de tres meses.",
+        "Expulsión y suspensión de la biblioteca del Paraninfo por una semana.",
+        "En este caso, impone la medida correctora el Director del Servicio de Informática."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 25. Respuesta validada por la plantilla oficial: Exclusión del uso de la biblioteca del Paraninfo por un periodo de tres meses.. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q025",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "Exclusión del uso de la biblioteca del Paraninfo por un periodo de tres meses."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-010",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q026-627321cb045d",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "Según el Reglamento de la Biblioteca de la Universidad de Cantabria, el grupo de dirección de la Biblioteca está formado por:",
+      "options": [
+        "Directora, Subdirectora, responsables de servicios técnicos y divisiones y la Administradora.",
+        "Directora, Subdirectora, responsables de servicios técnicos y un responsable de una división que actuara como secretario/a.",
+        "Directora, Subdirectora, Coordinadores y la Administradora, que actuará como secretaria.",
+        "Directora, Subdirectora, los responsables de los principales procesos, un responsable de división y la Administradora que actuará como secretaria."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 26. Respuesta validada por la plantilla oficial: Directora, Subdirectora, los responsables de los principales procesos, un responsable de división y la Administradora que actuará como secretaria.. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q026",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "Directora, Subdirectora, los responsables de los principales procesos, un responsable de división y la Administradora que actuará como secretaria."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-010",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q028-32a3a2e028fb",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "¿Cuáles son los procesos de ingreso tradicionales de los fondos bibliográficos en las bibliotecas universitarias? 1 ¢",
+      "options": [
+        "Compra, donación e intercambio.",
+        "Compra, donación y alquiler.",
+        "Compra, canje y relego.",
+        "Compra, relego y depósito."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 28. Respuesta validada por la plantilla oficial: Compra, donación e intercambio.. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q028",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "Compra, donación e intercambio."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-012",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q029-b4cd8087f3db",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "Respecto a la selección negativa, indique cuál de las siguientes respuestas es correcta:",
+      "options": [
+        "Implica siempre la destrucción de todos los documentos seleccionados.",
+        "Esla tarea primordial en las bibliotecas.",
+        "Supone exclusivamente el relego de documentos a los almacenes.",
+        "Los documentos expurgados pueden pasar a otras bibliotecas."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 29. Respuesta validada por la plantilla oficial: Los documentos expurgados pueden pasar a otras bibliotecas.. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q029",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "Los documentos expurgados pueden pasar a otras bibliotecas."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-012",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q031-665e16057da9",
+      "topicId": "uah-bib-t12-contenido",
+      "question": "¿Cuál de los siguientes NO es un tipo de adquisición de libros electrónicos?",
+      "options": [
+        "Compras a perpetuidad.",
+        "Suscripción anual.",
+        "Patron Driven Acquisitions.",
+        "Acuerdo transformativo."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 31. Respuesta validada por la plantilla oficial: Acuerdo transformativo.. Clasificada como Tema 12 (Gestión de la colección) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q031",
+        "path": "data/uah-bibliotecas-2025/referencias/12_03_gestion_coleccion_fuentes_web.md",
+        "highlightText": "Acuerdo transformativo."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-012",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q032-ba741a643003",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Estamos en el mostrador de préstamo de la división de Minas de la Biblioteca de la Universidad de Cantabria y nos devuelven unas obras con el tejuelo rojo. ¿En qué colección las tenemos que colocar?",
+      "options": [
+        "Monografías.",
+        "Básica.",
+        "ExtraBUC.",
+        "Referencia. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C Un iversi d a da Biblioteca, subgrupo C2, por el sistema general de acceso: libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Canta bria: (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 32. Respuesta validada por la plantilla oficial: Referencia. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C Un iversi d a da Biblioteca, subgrupo C2, por el sistema general de acceso: libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Canta bria: (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto). Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q032",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Referencia. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C Un iversi d a da Biblioteca, subgrupo C2, por el sistema general de acceso: libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Canta bria: (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q033-964c7e5a11e0",
+      "topicId": "uah-bib-t11-contenido",
+      "question": "Algunas de las colecciones impresas de la Biblioteca de la Universidad de Cantabria se conservan en almacenes y depósitos. ¿Pueden los usuarios acceder a estos fondos?",
+      "options": [
+        "No pueden acceder directamente ni tampoco consultarlos porque son materiales muy frágiles.",
+        "No pueden acceder directamente, pero sí solicitarlos al personal de la biblioteca.",
+        "Pueden acceder directamente siempre que pidan permiso en la división de la BUC correspondiente.",
+        "Pueden acceder directamente a estos fondos siguiendo la señalización."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 33. Respuesta validada por la plantilla oficial: No pueden acceder directamente, pero sí solicitarlos al personal de la biblioteca.. Clasificada como Tema 11 (Organización espacial y equipamiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q033",
+        "path": "data/uah-bibliotecas-2025/referencias/11_organizacion_espacial_equipamiento_buah.md",
+        "highlightText": "No pueden acceder directamente, pero sí solicitarlos al personal de la biblioteca."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-011",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q038-7d06833cfc64",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "Esta en el mostrador de préstamo de una biblioteca y tiene que colocar las obras cuyas signaturas se enumeran en las respuestas ¿Cuál sería la ordenación correcta?",
+      "options": [
+        "155 AVE, S. - 069 CON - 796.8 BAR, S -155 COR, P - 91 GOM, A. - 902 MON, R.",
+        "069 CON - 155 AVE, S. - 155 AWE, P - 796.8 BAR, S - 902 MON, R. - 91 GOM, A.",
+        "069 CON - 155 AWE, P - 155 AVE, S. - 796.8 BAR, S - 902 MON, R. - 91 GOM, A.",
+        "069 CON - 155 AWE, S. - 155 AVE, P - 796.8 BAR, S - 91 GOM, A. - 902 MON, R."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 38. Respuesta validada por la plantilla oficial: 069 CON - 155 AVE, S. - 155 AWE, P - 796.8 BAR, S - 902 MON, R. - 91 GOM, A.. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q038",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "069 CON - 155 AVE, S. - 155 AWE, P - 796.8 BAR, S - 902 MON, R. - 91 GOM, A."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-015",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q039-81df0a438019",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "La ordenación por currens en las bibliotecas tiene una serie de características entre las que NO se encuentra:",
+      "options": [
+        "Facilitar el recuento de fondos.",
+        "Identificar a golpe de vista la última adquisición.",
+        "Localizar rápidamente una obra.",
+        "Ordenar el fondo por materias."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 39. Respuesta validada por la plantilla oficial: Ordenar el fondo por materias.. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q039",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "Ordenar el fondo por materias."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-015",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q041-c203d9cff6e5",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "¿Qué credenciales son necesarias para poder acceder al préstamo de libros electrónicos de la plataforma eBUC en la Biblioteca de la Universidad de Cantabria?",
+      "options": [
+        "Número de DNIO NIE.",
+        "El usuario y la contraseña de la cuenta institucional de la UC.",
+        "La Tarjeta Universitaria Inteligente (TUI).",
+        "Una cuenta específica de la plataforma."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 41. Respuesta validada por la plantilla oficial: El usuario y la contraseña de la cuenta institucional de la UC.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q041",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "El usuario y la contraseña de la cuenta institucional de la UC."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-018",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q042-78c2bfba059d",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Un alumno que está haciendo su Erasmus en la UC, viene a la biblioteca porque necesita utilizar un portátil durante 60 días ¿Cuál de estas respuestas sería la más adecuada para ayudarle?",
+      "options": [
+        "Puede llevarse en préstamo cualquiera de los portátiles que estén disponibles en cualquier división de la biblioteca por el tiempo que necesite.",
+        "Puede solicitar en el servicio de informática de la UC uno de los portátiles que se ofrecen en préstamo rellenando un formulario.",
+        "Puede acudir a la división de Derecho-Económicas o a la del Paraninfo para solicitar un portátil de préstamo largo durante un mes, pudiendo hacer una renovación automática por el mismo periodo, si no hay personas en espera.",
+        "Puede solicitar un portátil de préstamo a domicilio a través de su tutor académico asignado."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 42. Respuesta validada por la plantilla oficial: Puede acudir a la división de Derecho-Económicas o a la del Paraninfo para solicitar un portátil de préstamo largo durante un mes, pudiendo hacer una renovación automática por el mismo periodo, si no hay personas en espera.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q042",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "Puede acudir a la división de Derecho-Económicas o a la del Paraninfo para solicitar un portátil de préstamo largo durante un mes, pudiendo hacer una renovación automática por el mismo periodo, si no hay personas en espera."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-018",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q043-3aff551b20d3",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Según el Acuerdo y manual de préstamo interbibliotecario y obtención de documentos de Rebiun, en la digitalización de documentos para suministro interbibliotecario, ¿Qué resolución se recomienda para documentos en color?",
+      "options": [
+        "300 ppi",
+        "600 ppi",
+        "200 ppi",
+        "400 ppi Pruebas selectivas para el ingreso en la Escala Auxiliar de U Cc | U n ive rel d a d Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 rl 9 de Ca nta b a (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 43. Respuesta validada por la plantilla oficial: 300 ppi. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q043",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "300 ppi"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-018",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q044-863755133e31",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "Según las condiciones de uso del préstamo de documentos de la Biblioteca de la Universidad de Cantabria, el personal jubilado de la UC puede tomar en préstamo hasta un total de:",
+      "options": [
+        "10items el personal Técnico de Administración y Servicios jubilado y 60 items el profesorado jubilado.",
+        "20items y renovarlos siempre y cuando no existan reservas sobre los mismos.",
+        "10items el personal Técnico de Administración y Servicios jubilado y 20 items el profesorado jubilado.",
+        "10 items todo el personal jubilado de la UC pudiendo renovarlos siempre y cuando no existan reservas sobre los mismos."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 44. Respuesta validada por la plantilla oficial: 10 items todo el personal jubilado de la UC pudiendo renovarlos siempre y cuando no existan reservas sobre los mismos.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q044",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "10 items todo el personal jubilado de la UC pudiendo renovarlos siempre y cuando no existan reservas sobre los mismos."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-018",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q046-8ca6f6762157",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "Indique cuál de las siguientes afirmaciones es correcta respecto a la Biblioteca de la Universidad de Cantabria:",
+      "options": [
+        "Elaccesoatodas las salas de lectura es libre.",
+        "Todas las salas de lectura están destinadas al estudio en silencio.",
+        "El acceso a las Salas de Grupo de la Biblioteca Universitaria está restringido.",
+        "En todas las Divisiones hay Salas de Grupo."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 46. Respuesta validada por la plantilla oficial: El acceso a las Salas de Grupo de la Biblioteca Universitaria está restringido.. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q046",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "El acceso a las Salas de Grupo de la Biblioteca Universitaria está restringido."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-010",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q052-8de5c08d5f85",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "Eltmarco DigComp define cinco grandes áreas de competencia ¿Cuál de las siguientes NO está incluida entre ellas?",
+      "options": [
+        "Información y tratamiento de datos.",
+        "Comunicación y colaboración.",
+        "Privacidad.",
+        "Creación de contenido digital."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 52. Respuesta validada por la plantilla oficial: Privacidad.. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q052",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Privacidad."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q055-eb40af96966d",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "¿Cuál de estos gestores bibliográficos es un software libre de código abierto?",
+      "options": [
+        "RefWorks.",
+        "Procite.",
+        "EndNote.",
+        "Zotero. Pruebas selectivas para el ingreso en la Escala Auxiliar de 1 ¬ U n ive rsi da d Biblioteca, subgrupo C2, por el sistema general de acceso libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Cantabria (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 55. Respuesta validada por la plantilla oficial: Zotero. Pruebas selectivas para el ingreso en la Escala Auxiliar de 1 ¬ U n ive rsi da d Biblioteca, subgrupo C2, por el sistema general de acceso libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Cantabria (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto). Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q055",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Zotero. Pruebas selectivas para el ingreso en la Escala Auxiliar de 1 ¬ U n ive rsi da d Biblioteca, subgrupo C2, por el sistema general de acceso libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de Cantabria (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q057-678e537533be",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "éEl repositorio institucional de la Universidad de Cantabria, UCrea, contempla la posibilidad de embargo temporal de las tesis?",
+      "options": [
+        "No, todas las tesis estan en acceso abierto.",
+        "Sí, por un periodo de tiempo establecido por el autor y un máximo de 5 años.",
+        "No, el embargo es perpetuo si así lo decide el autor.",
+        "Si, pero sólo si lo autoriza el director/a de la tesis."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 57. Respuesta validada por la plantilla oficial: Sí, por un periodo de tiempo establecido por el autor y un máximo de 5 años.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q057",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Sí, por un periodo de tiempo establecido por el autor y un máximo de 5 años."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-016",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q058-103565672b61",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿A qué nos referimos cuando hablamos de la publicación postprint?",
+      "options": [
+        "Al manuscrito aceptado por la revista y remitido para su publicación después de la revisión por pares, con la redacción definitiva del texto.",
+        "Al manuscrito aceptado por la revista pero que aún no ha pasado la revisión por pares.",
+        "Al manuscrito aceptado por la revista, que ha pasado la revisión por pares y presenta la versión final, es decir, la versión publicada (formato, logo, numeración...).",
+        "Al manuscrito rechazado por la revista."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 58. Respuesta validada por la plantilla oficial: Al manuscrito aceptado por la revista y remitido para su publicación después de la revisión por pares, con la redacción definitiva del texto.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q058",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Al manuscrito aceptado por la revista y remitido para su publicación después de la revisión por pares, con la redacción definitiva del texto."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-019",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q064-6b381e3de479",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "Se enumeran las descripciones en MARC21 del área de publicación de cuatro obras. Teniendo en cuenta que en tu biblioteca se utilizan ¢ en catalogación las RDA, ¿cuál de ellas es correcta?:",
+      "options": [
+        "260 5alS.I] Sb: Filmax Home Video $c 2006",
+        "260 Sa[Madrid] Sb: Laboratorio Educativo [etc] Sc 2001",
+        "264 1 SaBuenos Aires:SbEditorial Médica Panamericana, Sc 1987",
+        "264 1 SaBarcelona [etc]:SbGraó, $cé 2004?"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 64. Respuesta validada por la plantilla oficial: 264 1 SaBuenos Aires:SbEditorial Médica Panamericana, Sc 1987. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q064",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "264 1 SaBuenos Aires:SbEditorial Médica Panamericana, Sc 1987"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q065-9066430dc93c",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "El protocolo que permite el intercambio de metada tos entre repositorios es:",
+      "options": [
+        "OAI-PMH",
+        "HTTP",
+        "OpenURL",
+        "Open Data"
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 65. Respuesta validada por la plantilla oficial: OAI-PMH. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q065",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "OAI-PMH"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-016",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q066-dc118157ed60",
+      "topicId": "uah-bib-t14-contenido",
+      "question": "¿Cuál es el ISSN específico que reúne los diferentes soportes en los que se edita una misma publicación seriada?",
+      "options": [
+        "ISSN-E",
+        "ISSN-K",
+        "ISSN-L",
+        "ISSN-V"
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 66. Respuesta validada por la plantilla oficial: ISSN-L. Clasificada como Tema 14 (Identificadores documentales) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q066",
+        "path": "data/uah-bibliotecas-2025/referencias/14_identificadores_documentales.md",
+        "highlightText": "ISSN-L"
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-014",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q072-3a2d9a9708ff",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "De estas afirmaciones, cuál expresa una diferencia notable entre los SIGB y las plataformas de servicios bibliotecarios:",
+      "options": [
+        "Las plataformas integran la gestión de recursos electrónicos.",
+        "Las plataformas no permiten hacer consultas retrospectivas.",
+        "Los SIGB incluyen una herramienta de descubrimiento.",
+        "Los SIGB no tienen control de autoridades."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 72. Respuesta validada por la plantilla oficial: Las plataformas integran la gestión de recursos electrónicos.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q072",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Las plataformas integran la gestión de recursos electrónicos."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-019",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q073-5e97b019e7db",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "El OPAC de Absysnet es de diseño <responsivo= lo que significa que:",
+      "options": [
+        "Darespuesta a todas las búsquedas bibliográficas.",
+        "Tiene un asistente de voz.",
+        "Se adapta a las pantallas de múltiples dispositivos.",
+        "Se puede usar en cualquier idioma."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 73. Respuesta validada por la plantilla oficial: Se adapta a las pantallas de múltiples dispositivos.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q073",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Se adapta a las pantallas de múltiples dispositivos."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-019",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q085-73e7bc5bb2d1",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Cuál de las siguientes NO es una herramienta de almacenamiento de archivos en la nube?",
+      "options": [
+        "Dropbox.",
+        "Google Drive. Pruebas selectivas para el ingreso en la Escala Auxiliar de U C | Unive rsidad Biblioteca, subgrupo C2, por el sistema general de acceso. libre (Resolución Rectoral 843/25, de 7 de julio de 2025 de e antabria 9 (BOE de 18 de julio), corregida por Resolución Rectoral 903/25 de 29 de julio de 2025 (BOE de 2 de agosto)",
+        "WinZip.",
+        "Microsoft Onedrive."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 85. Respuesta validada por la plantilla oficial: WinZip.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q085",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "WinZip."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-019",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q086-39e77999b31e",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Gon cuál de estas vías de acceso abierto relacionas los APC (Article Processing Charges)?:",
+      "options": [
+        "Bronce.",
+        "Diamante.",
+        "Dorada.",
+        "Preprint."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 86. Respuesta validada por la plantilla oficial: Dorada.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q086",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Dorada."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-016",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q087-b19376bafc48",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál de estos aspectos NO se contempla en la Ciencia Abierta?",
+      "options": [
+        "Ciencia ciudadana.",
+        "Datos abiertos.",
+        "Revisión por pares abierta.",
+        "Evaluación de la docencia abierta."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 87. Respuesta validada por la plantilla oficial: Evaluación de la docencia abierta.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q087",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Evaluación de la docencia abierta."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-016",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q088-979a0ce8a2f0",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál de las siguientes afirmaciones sobre los datos de investigación NO es correcta?",
+      "options": [
+        "Sustentan y justifican las aportaciones científicas.",
+        "Son el resultado de la aplicación de diferentes metodologías.",
+        "Tienen que estar en acceso abierto en todo momento.",
+        "Se utilizan en cualquier rama del conocimiento."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 88. Respuesta validada por la plantilla oficial: Tienen que estar en acceso abierto en todo momento.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q088",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Tienen que estar en acceso abierto en todo momento."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-016",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-cantabria-c2-2025-q090-8e92a63e1bce",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "El acceso abierto a la producción científica se caracteriza por:",
+      "options": [
+        "Ceder los derechos de autor a las editoriales.",
+        "Publicar en revistas sin revisión por pares.",
+        "Llevar una licencia de dominio público.",
+        "Permitir el acceso libre a las publicaciones científicas."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Cantabria 2025 - Escala Auxiliar de Biblioteca C2, pregunta 90. Respuesta validada por la plantilla oficial: Permitir el acceso libre a las publicaciones científicas.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "cantabria-c2-2025#q090",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Permitir el acceso libre a las publicaciones científicas."
+      },
+      "tags": [
+        "examen-oficial",
+        "cantabria-c2-2025",
+        "uah-tema-016",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q002-e98ba3c86c7e",
+      "topicId": "uah-bib-t01-contenido",
+      "question": "La Constitución Española establece que el Fiscal General del Estado será nombrado por el Rey, a propuesta de:",
+      "options": [
+        "El Ministro de Justicia.",
+        "El Consejo General del Poder Judicial.",
+        "El Gobierno.",
+        "El Tribunal Supremo."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 2. Respuesta validada por la plantilla oficial: El Consejo General del Poder Judicial.. Clasificada como Tema 1 (Constitución Española) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q002",
+        "path": "data/general/01_constitucion_espanola_1978.md",
+        "highlightText": "El Consejo General del Poder Judicial."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-001",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q010-b50c28a6ee8d",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "Señale cuál de los siguientes NO es un grupo permanente de trabajo de REBIUN:",
+      "options": [
+        "Acceso al documento.",
+        "Personal.",
+        "Repositorios.",
+        "Comunicación."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 10. Respuesta validada por la plantilla oficial: Comunicación.. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q010",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "Comunicación."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q013-aa48ed37f0d6",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según la Ley Orgánica 2/2023 del Sistema Universitario:",
+      "options": [
+        "Los estudios de Doctorado tienen como finalidad la adquisición de las competencias y las habilidades concernientes a la investigación dentro de un ámbito del conocimiento científico, técnico, humanístico, artístico o cultural.",
+        "Los estudios de Máster Universitario tienen como finalidad la obtención por parte del estudiantado de una formación básica y generalista en una disciplina determinada.",
+        "Los estudios de Grado tienen como finalidad la obtención por parte del estudiantado de una formación avanzada y especializada en una disciplina determinada.",
+        "los estudios de Doctorado tienen como finalidad la formación avanzada, de carácter especializado temáticamente, o de carácter multidisciplinar o interdisciplinar, dirigida a la especialización académica o profesional, o bien encaminada a la iniciación en tareas de investigación."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 13. Respuesta validada por la plantilla oficial: Los estudios de Doctorado tienen como finalidad la adquisición de las competencias y las habilidades concernientes a la investigación dentro de un ámbito del conocimiento científico, técnico, humanístico, artístico o cultural.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q013",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Los estudios de Doctorado tienen como finalidad la adquisición de las competencias y las habilidades concernientes a la investigación dentro de un ámbito del conocimiento científico, técnico, humanístico, artístico o cultural."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q015-0533ba028b88",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Según consta en el artículo \"La Biblioteca Universitaria de Zaragoza\" de la exdirectora de la misma, Remedios Moralejo Álvarez ¿en qué año se abre al público la BUZ?",
+      "options": [
+        "1796",
+        "1696",
+        "1596",
+        "1542"
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 15. Respuesta validada por la plantilla oficial: 1542. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q015",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "1542"
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q017-37800da2cd6c",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Grupo 9 de Universidades es una asociación sin ánimo de lucro formada por las universidades públicas españolas que son únicas universidades públicas en sus respectivas Comunidades Autónomas: Universidad de Cantabria, Universidad de Castilla La Mancha, Universidad de Extremadura, Universitat de les Illes Balears, Universidad de La Rioja, Universidad de Oviedo, Universidad del País Vasco / Euskal Herriko Unibertsitatea, Universidad Pública de Navarra, Universidad de Zaragoza. Contesta cuál es la respuesta correcta sobre el G9:",
+      "options": [
+        "Además, desde 2023, la Universidad de Murcia forma parte del G-9 como universidad colaboradora.",
+        "Existe un Grupo de Trabajo de Bibliotecas incluido en la Sectorial de Investigación.",
+        "Consta de 9 Comisiones Sectoriales.",
+        "Todas las anteriores son correctas."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 17. Respuesta validada por la plantilla oficial: Todas las anteriores son correctas.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q017",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Todas las anteriores son correctas."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-003",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q020-deaf0167cbec",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "REBIUN en su Línea estratégica \"Equipos y capacitación profesional\", tiene como objetivos:",
+      "options": [
+        "Elaborar un temario base común para las distintas oposiciones en las bibliotecas universitarias.",
+        "Mejora de la calidad de los repositorios REBIUN.",
+        "Elaborar, mantener y difundir un catálogo de cursos de formación y expertos por competencias, integrado en la herramienta de competencias.",
+        "a y c son correctas."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 20. Respuesta validada por la plantilla oficial: a y c son correctas.. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q020",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "a y c son correctas."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q021-2a8ef67eb441",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "Las siglas OPAC significan:",
+      "options": [
+        "Online Processing Access Catalog.",
+        "Online Public Access Catalog.",
+        "Online Public Automated Catalog.",
+        "Online Processing Automated Catalog."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 21. Respuesta validada por la plantilla oficial: Online Public Access Catalog.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q021",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Online Public Access Catalog."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q024-a3f5f2056b30",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "Señale a cuál de los siguientes colectivos es aplicable el Pacto del Personal funcionario de Administración y Servicios de la Universidad de Zaragoza:",
+      "options": [
+        "Al personal docente e investigador funcionario.",
+        "Al personal funcionario interino.",
+        "Al personal eventual a que se refiere el art. 20.2 de la Ley 30/84, de 2 de agosto.",
+        "Todas son correctas."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 24. Respuesta validada por la plantilla oficial: Al personal funcionario interino.. Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q024",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "Al personal funcionario interino."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-002",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q025-5ab3c2592026",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "Según las Normas y directrices para bibliotecas universitarias y científicas de REBIUN, la colección debe estar:",
+      "options": [
+        "La mayor parte en libre acceso para los usuarios bajo una clasificación temática.",
+        "Toda en libre acceso para los usuarios bajo una clasificación temática.",
+        "Toda en depósito sin libre acceso para los usuarios.",
+        "La mayor parte en libre acceso para los usuarios bajo cualquier clasificación."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 25. Respuesta validada por la plantilla oficial: La mayor parte en libre acceso para los usuarios bajo una clasificación temática.. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q025",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "La mayor parte en libre acceso para los usuarios bajo una clasificación temática."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q028-9d0e367ca728",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "¿En qué área del Marco DIGCOMP está incluida la competencia referida a los derechos de propiedad intelectual y las licencias de uso?",
+      "options": [
+        "Información y tratamiento de datos.",
+        "Comunicación y colaboración.",
+        "Creación de contenidos.",
+        "Seguridad."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 28. Respuesta validada por la plantilla oficial: Creación de contenidos.. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q028",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Creación de contenidos."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q032-eb33b8ffbcb0",
+      "topicId": "uah-bib-t04-contenido",
+      "question": "Según el Acuerdo de 29 de junio de 2022, del Consejo de Gobierno de la Universidad de Zaragoza, por el que se aprueba la política de seguridad de la información y protección de datos personales de la Universidad de Zaragoza, con carácter ordinario, los sistemas de información serán objeto de una auditoría regular ordinaria",
+      "options": [
+        "Todos los años, salvo que concurran impedimentos de fuerza mayor no imputables a la Universidad.",
+        "Al menos, cada dos años.",
+        "Al menos, cada tres años.",
+        "Al menos, cada tres años, o a los tres años de la última auditoría extraordinaria."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 32. Respuesta validada por la plantilla oficial: Al menos, cada dos años.. Clasificada como Tema 4 (Protección de datos) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q032",
+        "path": "data/general/04_Ley_Organica_3_2018_de_5_de_diciembre_de_Proteccion_de_Datos_Personales_y_garantia_de_los_derechos_digitales.md",
+        "highlightText": "Al menos, cada dos años."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-004",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q034-6468150ee7d9",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "¿Cuál de estas utilidades NO proporciona la plataforma de servicios bibliotecarios FOLIO a la Biblioteca de la Universidad de Zaragoza?",
+      "options": [
+        "Inventario.",
+        "Adquisición.",
+        "Circulación.",
+        "Reservas."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 34. Respuesta validada por la plantilla oficial: Adquisición.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q034",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "Adquisición."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q037-af97bb9bc95a",
+      "topicId": "uah-bib-t19-contenido",
+      "question": "FOLIO es una plataforma de servicios bibliotecarios",
+      "options": [
+        "De código abierto.",
+        "De código cerrado.",
+        "De código secuencia.",
+        "De código ordinario."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 37. Respuesta validada por la plantilla oficial: De código abierto.. Clasificada como Tema 19 (LSP y herramientas de descubrimiento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q037",
+        "path": "data/uah-bibliotecas-2025/referencias/19_lsp_buscador_uah.md",
+        "highlightText": "De código abierto."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-019",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q039-294a77efe7bc",
+      "topicId": "uah-bib-t22-contenido",
+      "question": "Según el artículo 37 de la Ley de Propiedad Intelectual, los documentos servidos entre bibliotecas se facilitan exclusivamente:",
+      "options": [
+        "Con fines de investigación personal de carácter cultural o científico.",
+        "Con fines de investigación personal de carácter académico.",
+        "Con fines de investigación personal de carácter científico o comercial.",
+        "Con fines de investigación personal de carácter universitario."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 39. Respuesta validada por la plantilla oficial: Con fines de investigación personal de carácter cultural o científico.. Clasificada como Tema 22 (Propiedad intelectual y Creative Commons) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q039",
+        "path": "data/uah-bibliotecas-2025/referencias/22_ley_propiedad_intelectual.md",
+        "highlightText": "Con fines de investigación personal de carácter cultural o científico."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-022",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q046-05db1c1461ad",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "Según el V Plan estratégico de REBIUN para el periodo 2024-2027, la línea estratégica 1 habla de \"la biblioteca en el contexto de la transformación digital\". ¿Qué áreas de actuación contempla? Señale la respuesta correcta.",
+      "options": [
+        "Estrategias y políticas para el desarrollo de la ciencia abierta, con el objeto de marcas unas pautas que sirvan a las bibliotecas como referente válido.",
+        "Modelos de organización de los equipos de trabajo, impulsando modelos organizativos dinámicos y flexibles.",
+        "Transición al libro electrónico, siendo REBIUN el agente impulsor de la homogeneización de los modelos editoriales.",
+        "Desarrollo e impulso del talento profesional, permitiendo la adaptación de los perfiles profesionales a la transformación digital."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 46. Respuesta validada por la plantilla oficial: Transición al libro electrónico, siendo REBIUN el agente impulsor de la homogeneización de los modelos editoriales.. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q046",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "Transición al libro electrónico, siendo REBIUN el agente impulsor de la homogeneización de los modelos editoriales."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-020",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q051-584f24346faf",
+      "topicId": "uah-bib-t18-contenido",
+      "question": "En el servicio de préstamo de ordenadores portátiles de la Biblioteca de la Universidad de Zaragoza",
+      "options": [
+        "Se permiten reservas y se pueden devolver en cualquier biblioteca.",
+        "Se permiten reservas y hay que devolverlo en la biblioteca prestataria.",
+        "No se permiten reservas y se pueden devolver en cualquier biblioteca.",
+        "No se permiten reservas y hay que devolverlo en la biblioteca prestataria."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 51. Respuesta validada por la plantilla oficial: No se permiten reservas y hay que devolverlo en la biblioteca prestataria.. Clasificada como Tema 18 (Préstamo, salas y acceso al documento) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q051",
+        "path": "data/uah-bibliotecas-2025/referencias/18_prestamo_salas_acceso_documento.md",
+        "highlightText": "No se permiten reservas y hay que devolverlo en la biblioteca prestataria."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-018",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q056-60098668d058",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Cuál de estos elementos NO aparecerá en la referencia bibliográfica de un artículo de revista?",
+      "options": [
+        "Año.",
+        "Título de la revista.",
+        "ISBN.",
+        "Páginas que abarca el artículo."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 56. Respuesta validada por la plantilla oficial: ISBN.. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q056",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "ISBN."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q058-e5d777abdc49",
+      "topicId": "uah-bib-t02-contenido",
+      "question": "Según el Texto Refundido de la la Ley del Estatuto Básico del Empleado Público en relación con el personal eventual ¿qué respuesta es la correcta?",
+      "options": [
+        "La condición de personal eventual podrá constituir mérito para el acceso a la Función Pública o para la promoción interna.",
+        "Al personal eventual no le será aplicable el régimen general de los funcionarios de carrera",
+        "El nombramiento y cese serán libres.",
+        "El personal eventual tiene carácter permanente."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 58. Respuesta validada por la plantilla oficial: El nombramiento y cese serán libres.. Clasificada como Tema 2 (EBEP) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q058",
+        "path": "data/general/02_Estatuto_Basico_del_Empleado_Publico.md",
+        "highlightText": "El nombramiento y cese serán libres."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-002",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q060-53a773f9ae6c",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "Según el \"Manifiesto de la IFLA/UNESCO sobre Bibliotecas Digitales\" una Biblioteca Digital es:",
+      "options": [
+        "Una colección en línea de objetos digitales de buena calidad, creados o recopilados y administrados de conformidad con principios aceptados en el plano internacional para la creación de colecciones.",
+        "Una lista de enlaces organizados con infraestructura física que hace posible la creación y mantenimiento de bases de datos.",
+        "Es una colección estructurada y organizada de documentos digitales, desarrollada según una política y un esquema conceptual, que ofrece servicios transversales a sus usuarios, fundamentados en la colección y la preservación del patrimonio.",
+        "Una recopilación de documentos digitalizados, bases de datos y revistas electrónicas con interfaz web."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 60. Respuesta validada por la plantilla oficial: Una colección en línea de objetos digitales de buena calidad, creados o recopilados y administrados de conformidad con principios aceptados en el plano internacional para la creación de colecciones.. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q060",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "Una colección en línea de objetos digitales de buena calidad, creados o recopilados y administrados de conformidad con principios aceptados en el plano internacional para la creación de colecciones."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-021",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q064-ac21bf33a6c9",
+      "topicId": "uah-bib-t17-contenido",
+      "question": "¿Qué mide el Factor de Impacto (JIF) del Journal Citation Reports (JCR)?",
+      "options": [
+        "El impacto de una revista en función de las citas recibidas por sus artículos indexados en la base de datos Scopus.",
+        "El impacto de una revista en función de las citas recibidas por sus artículos indexados en el portal de indicadores de la producción científica de Dialnet.",
+        "El impacto de una revista en función de las citas recibidas por sus artículos indexados en la Web of Science.",
+        "El impacto de una revista en función de las citas recibidas por sus artículos indexados en el recuento de citas de Google Académico."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 64. Respuesta validada por la plantilla oficial: El impacto de una revista en función de las citas recibidas por sus artículos indexados en la Web of Science.. Clasificada como Tema 17 (Servicios al usuario) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q064",
+        "path": "data/uah-bibliotecas-2025/referencias/17_carta_servicios_buah.md",
+        "highlightText": "El impacto de una revista en función de las citas recibidas por sus artículos indexados en la Web of Science."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-017",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-libre-2024-q069-e8e5736e9c31",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "De estos tipos de documentos ¿Cuál NO está incluido en el Repositorio Institucional Zaguán?",
+      "options": [
+        "Preprints.",
+        "Datos abiertos.",
+        "Fondos personales.",
+        "Boletín Oficial de Aragón."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Turno libre, pregunta 69. Respuesta validada por la plantilla oficial: Boletín Oficial de Aragón.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-libre-2024#q069",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "Boletín Oficial de Aragón."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-libre-2024",
+        "uah-tema-016",
+        "prioridad-alta"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q015-cf4291b99d9b",
+      "topicId": "uah-bib-t10-contenido",
+      "question": "En la Biblioteca de la Universidad de Zaragoza, los contactos con los editores para poner en funcionamiento cada plataforma de libro electrónico la gestiona",
+      "options": [
+        "La Comisión de la Biblioteca.",
+        "El Servicio de Suscripciones.",
+        "Cada director de biblioteca.",
+        "El director de la Biblioteca Universitaria."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 15. Respuesta validada por la plantilla oficial: El director de la Biblioteca Universitaria.. Clasificada como Tema 10 (Servicio de Biblioteca) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q015",
+        "path": "data/uah-bibliotecas-2025/referencias/10_reglamento_biblioteca_uah.md",
+        "highlightText": "El director de la Biblioteca Universitaria."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-010",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q017-67dba3b4b268",
+      "topicId": "uah-bib-t15-contenido",
+      "question": "En la CDU el signo (…) denominado \"paréntesis\" tiene el uso de:",
+      "options": [
+        "Auxiliar común de razas y pueblos.",
+        "Auxiliar común de lengua.",
+        "Auxiliar común de lugar.",
+        "Auxiliar común de tiempo."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 17. Respuesta validada por la plantilla oficial: Auxiliar común de lugar.. Clasificada como Tema 15 (Análisis documental y clasificación) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q017",
+        "path": "data/uah-bibliotecas-2025/referencias/15_analisis_documental_cdu_uah.md",
+        "highlightText": "Auxiliar común de lugar."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-015",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q021-5df1210ed70d",
+      "topicId": "uah-bib-t16-contenido",
+      "question": "¿Cuál es la respuesta correcta?:",
+      "options": [
+        "TiraBUZón es un boletín informativo de la BUZ, iBUZ es un blog de la BUZ, AlcorZe es una herramienta de búsqueda unificada de la BUZ, Zaguán es el repositorio de la UZ.",
+        "iBUZ es un boletín informativo de la BUZ, TiraBUZón es un blog de la BUZ, Zaguán es una herramienta de búsqueda unificada de la BUZ, AlcorZe es el repositorio de la UZ.",
+        "iBUZ es un boletín informativo de la BUZ, TiraBUZón es un blog de la BUZ, AlcorZe es una herramienta de búsqueda unificada de la BUZ, Zaguán es el repositorio de la UZ.",
+        "iBUZ es un boletín informativo de la BUZ, TiraBUZón es un blog de la BUZ, Zarigüeya es una herramienta de búsqueda unificada de la BUZ, Zaguán es el repositorio de la UZ."
+      ],
+      "correctIndex": 2,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 21. Respuesta validada por la plantilla oficial: iBUZ es un boletín informativo de la BUZ, TiraBUZón es un blog de la BUZ, AlcorZe es una herramienta de búsqueda unificada de la BUZ, Zaguán es el repositorio de la UZ.. Clasificada como Tema 16 (Acceso abierto y repositorios) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q021",
+        "path": "data/uah-bibliotecas-2025/referencias/16_02_ciencia_abierta_complemento.md",
+        "highlightText": "iBUZ es un boletín informativo de la BUZ, TiraBUZón es un blog de la BUZ, AlcorZe es una herramienta de búsqueda unificada de la BUZ, Zaguán es el repositorio de la UZ."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-016",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q028-56855bb40c69",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "En el marco de la Estrategia y Calidad de la BUZ, qué respuesta NO es correcta:",
+      "options": [
+        "Para conocer la satisfacción del usuario con nuestros servicios y para poder atender a sus expectativas, en la biblioteca se realizan encuestas anuales de satisfacción.",
+        "La BUZ presenta anualmente una Memoria que resume las actividades y resultados más relevantes de su actividad.",
+        "Es objetivo de la BUZ dejar constancia de la gestión de los recursos económicos asignados. Por ello, anualmente, se evalúa el gasto total de la Universidad en adquisiciones y su distribución.",
+        "La BUZ se alinea con los planes de la Universidad de Zaragoza y los servicios de la misma para la consecución de la Agenda 2030 y los ODS. Para ello se necesitan alianzas sólidas y eficaces a todos los niveles."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 28. Respuesta validada por la plantilla oficial: Para conocer la satisfacción del usuario con nuestros servicios y para poder atender a sus expectativas, en la biblioteca se realizan encuestas anuales de satisfacción.. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q028",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "Para conocer la satisfacción del usuario con nuestros servicios y para poder atender a sus expectativas, en la biblioteca se realizan encuestas anuales de satisfacción."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q031-856036f1f305",
+      "topicId": "uah-bib-t13-contenido",
+      "question": "¿Cuál es la principal diferencia entre los campos RDA 337 y 338?",
+      "options": [
+        "El campo 337 describe el tipo de contenido y el 338 el tipo de soporte.",
+        "El campo 337 describe el tipo de medio y el 338 el tipo de soporte.",
+        "El campo 337 describe el tipo de contenido y el 338 describe el tipo de medio.",
+        "El campo 337 es opcional y el 338 es obligatorio."
+      ],
+      "correctIndex": 1,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 31. Respuesta validada por la plantilla oficial: El campo 337 describe el tipo de medio y el 338 el tipo de soporte.. Clasificada como Tema 13 (Proceso técnico, MARC, FRBR y RDA) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q031",
+        "path": "data/uah-bibliotecas-2025/referencias/13_proceso_tecnico_marc21_frbr_rda.md",
+        "highlightText": "El campo 337 describe el tipo de medio y el 338 el tipo de soporte."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-013",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q036-07569a4ac218",
+      "topicId": "uah-bib-t21-contenido",
+      "question": "Cuando hablamos de \"revisión por pares\" ¿A qué nos referimos?",
+      "options": [
+        "La revisión por pares es un procedimiento usado en la edición académica y científica, que tiene como objetivo fundamental asegurar la calidad y validez de los trabajos, antes de su publicación y de su difusión al resto de la comunidad científica.",
+        "La revisión por pares hace referencia a la revisión y validez de la documentación aportada al Portal de Archivos Españoles.",
+        "La revisión por pares es un procedimiento usado en la edición académica y científica, que tiene como objetivo fundamental asegurar mediante tecnología blockchain la trazabilidad de los trabajos académicos.",
+        "Las respuestas a) y c) son correctas."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 36. Respuesta validada por la plantilla oficial: La revisión por pares es un procedimiento usado en la edición académica y científica, que tiene como objetivo fundamental asegurar la calidad y validez de los trabajos, antes de su publicación y de su difusión al resto de la comunidad científica.. Clasificada como Tema 21 (Calidad y EFQM) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q036",
+        "path": "data/uah-bibliotecas-2025/referencias/21_calidad_rebiun_efqm_buah.md",
+        "highlightText": "La revisión por pares es un procedimiento usado en la edición académica y científica, que tiene como objetivo fundamental asegurar la calidad y validez de los trabajos, antes de su publicación y de su difusión al resto de la comunidad científica."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-021",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q041-50b4cabae88f",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Grupo 9 de Universidades es una asociación sin ánimo de lucro formada por las universidades públicas españolas que son únicas universidades públicas en sus respectivas Comunidades Autónomas: Universidad de Cantabria, Universidad de Castilla La Mancha, Universidad de Extremadura, Universitat de les Illes Balears, Universidad de La Rioja, Universidad de Oviedo, Universidad del País Vasco / Euskal Herriko Unibertsitatea, Universidad Pública de Navarra, Universidad de Zaragoza. Conteste cuál es la respuesta correcta sobre el G9:",
+      "options": [
+        "Además, desde 2023, la Universidad de Murcia forma parte del G-9 como universidad colaboradora.",
+        "Existe un Grupo de Trabajo de Bibliotecas incluido en la Sectorial de Investigación.",
+        "Consta de 9 Comisiones Sectoriales.",
+        "Todas las anteriores son correctas."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 41. Respuesta validada por la plantilla oficial: Todas las anteriores son correctas.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q041",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Todas las anteriores son correctas."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q045-a546e8a4035e",
+      "topicId": "uah-bib-t20-contenido",
+      "question": "Según las Normas y directrices para bibliotecas universitarias y científicas de REBIUN, la colección debe estar",
+      "options": [
+        "La mayor parte en libre acceso para los usuarios bajo una clasificación temática.",
+        "Toda en libre acceso para los usuarios bajo una clasificación temática.",
+        "Toda en depósito sin libre acceso para los usuarios.",
+        "La mayor parte en libre acceso para los usuarios bajo cualquier clasificación."
+      ],
+      "correctIndex": 0,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 45. Respuesta validada por la plantilla oficial: La mayor parte en libre acceso para los usuarios bajo una clasificación temática.. Clasificada como Tema 20 (Cooperación bibliotecaria) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q045",
+        "path": "data/uah-bibliotecas-2025/referencias/20_02_cooperacion_rebiun_madrono.md",
+        "highlightText": "La mayor parte en libre acceso para los usuarios bajo una clasificación temática."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-020",
+        "prioridad-media"
+      ]
+    },
+    {
+      "id": "uah-exam-uz-c1-pi-2024-q047-1528dd5133e2",
+      "topicId": "uah-bib-t03-contenido",
+      "question": "Tal y como establece la Ley Orgánica 2/2023 del Sistema Universitario, la provisión de puestos de personal técnico, de gestión y de administración y servicios en las universidades",
+      "options": [
+        "Se realizará mediante el sistema de concurso oposición y excepcionalmente mediante el sistema de concurso.",
+        "En ningún caso podrá presentarse personal perteneciente a cuerpos y escalas de otras Administraciones Públicas.",
+        "Se realizará mediante el sistema de concurso y podrá concurrir su propio personal exclusivamente.",
+        "Se realizará mediante el sistema de concurso y podrá concurrir tanto su propio personal, como el personal de otras universidades, así como, en las condiciones que reglamentariamente se determinen, el personal perteneciente a cuerpos y escalas de las Administraciones Públicas."
+      ],
+      "correctIndex": 3,
+      "explanation": "Pregunta procedente de examen oficial/real: Universidad de Zaragoza 2024 - Técnicos Especialistas de Biblioteca C1 - Promoción interna, pregunta 47. Respuesta validada por la plantilla oficial: Se realizará mediante el sistema de concurso y podrá concurrir tanto su propio personal, como el personal de otras universidades, así como, en las condiciones que reglamentariamente se determinen, el personal perteneciente a cuerpos y escalas de las Administraciones Públicas.. Clasificada como Tema 3 (LOSU) para practicar el temario UAH C1.",
+      "origin": "oficial",
+      "source": {
+        "materialId": "uz-c1-pi-2024#q047",
+        "path": "data/general/03_Ley_Organica_2_2023_de_22_de_marzo_del_Sistema_Universitario.md",
+        "highlightText": "Se realizará mediante el sistema de concurso y podrá concurrir tanto su propio personal, como el personal de otras universidades, así como, en las condiciones que reglamentariamente se determinen, el personal perteneciente a cuerpos y escalas de las Administraciones Públicas."
+      },
+      "tags": [
+        "examen-oficial",
+        "uz-c1-pi-2024",
+        "uah-tema-003",
+        "prioridad-media"
+      ]
     }
-  ]
+  ],
+  "meta": {
+    "updatedAt": "2026-05-02T17:48:22.313Z",
+    "officialExamQuestions": 259
+  }
 }


### PR DESCRIPTION
## Resumen
- añade 259 preguntas extraídas de exámenes oficiales/reales y clasificadas por temas UAH C1
- marca las nuevas preguntas oficiales con `origin: "oficial"` para filtrarlas separadas de `curada` y `refuerzo`
- analiza de forma privada 23 backups Opositatest con 1.605 preguntas únicas parseadas, correcta detectada y 1.571 explicaciones localizadas
- añade 44 preguntas originales de refuerzo `origin: "opositatest-referencia"`, dos por cada tema UAH C1, validadas contra fuentes oficiales/UAH y sin reproducir contenido literal comercial
- mejora las etiquetas de filtro para mostrar “Opositatest ref.”

## Validación
- npm run validate-schemas
- npm run generate-flatbuffers
- npm run lint
- npm run build

Nota: los backups de Opositatest se usan solo como señal privada de cobertura/estilo; el PR no publica stems/opciones/respuestas/explicaciones literales del banco comercial.